### PR TITLE
Angular Material dark theme + stats panel + responsive layout

### DIFF
--- a/metro/package-lock.json
+++ b/metro/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.0.0",
       "dependencies": {
         "@angular/animations": "~21.2.0",
+        "@angular/cdk": "~21.2.0",
         "@angular/common": "~21.2.0",
         "@angular/compiler": "~21.2.0",
         "@angular/core": "~21.2.0",
         "@angular/forms": "~21.2.0",
+        "@angular/material": "~21.2.0",
         "@angular/platform-browser": "~21.2.0",
         "@angular/platform-browser-dynamic": "~21.2.0",
         "@angular/router": "~21.2.0",
@@ -681,6 +683,22 @@
         "@angular/core": "21.2.8"
       }
     },
+    "node_modules/@angular/cdk": {
+      "version": "21.2.6",
+      "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-21.2.6.tgz",
+      "integrity": "sha512-1PBzFf+um/VZ1dFF6cT72Zsq+9C/ZWF9m5dP0uHJgo4psX3yMBoZlZu5YomBiAQ/ePSkqCuryv1vrelK+yd3Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^8.0.0",
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
     "node_modules/@angular/cli": {
       "version": "21.2.7",
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-21.2.7.tgz",
@@ -818,6 +836,23 @@
         "@angular/common": "21.2.8",
         "@angular/core": "21.2.8",
         "@angular/platform-browser": "21.2.8",
+        "rxjs": "^6.5.3 || ^7.4.0"
+      }
+    },
+    "node_modules/@angular/material": {
+      "version": "21.2.6",
+      "resolved": "https://registry.npmjs.org/@angular/material/-/material-21.2.6.tgz",
+      "integrity": "sha512-V4hblb5ekgXb5x+UXKRs2yiB0hZUkUJbYwGseMglkCeWQlLM4u6amlsUzP4uOwIWFOkM/ZYl9qz4YGZnvMAyjw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/cdk": "21.2.6",
+        "@angular/common": "^21.0.0 || ^22.0.0",
+        "@angular/core": "^21.0.0 || ^22.0.0",
+        "@angular/forms": "^21.0.0 || ^22.0.0",
+        "@angular/platform-browser": "^21.0.0 || ^22.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
@@ -8345,7 +8380,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -12043,7 +12077,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"

--- a/metro/package.json
+++ b/metro/package.json
@@ -11,10 +11,12 @@
   "private": true,
   "dependencies": {
     "@angular/animations": "~21.2.0",
+    "@angular/cdk": "~21.2.0",
     "@angular/common": "~21.2.0",
     "@angular/compiler": "~21.2.0",
     "@angular/core": "~21.2.0",
     "@angular/forms": "~21.2.0",
+    "@angular/material": "~21.2.0",
     "@angular/platform-browser": "~21.2.0",
     "@angular/platform-browser-dynamic": "~21.2.0",
     "@angular/router": "~21.2.0",

--- a/metro/src/app/footer/footer.component.css
+++ b/metro/src/app/footer/footer.component.css
@@ -1,3 +1,24 @@
-.footer {
-  background: aqua;
+.app-footer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 16px;
+  background: #1e1e1e;
+  color: #888;
+  font-size: 0.8rem;
+  border-top: 1px solid #333;
+}
+
+.app-footer a {
+  color: #90caf9;
+  text-decoration: none;
+}
+
+.app-footer a:hover {
+  text-decoration: underline;
+}
+
+.separator {
+  opacity: 0.4;
 }

--- a/metro/src/app/footer/footer.component.html
+++ b/metro/src/app/footer/footer.component.html
@@ -1,1 +1,5 @@
-<p class="footer">footer</p>
+<footer class="app-footer">
+  <span>Metro Madrid Simulator</span>
+  <span class="separator">·</span>
+  <a href="https://github.com/santifinland/metro" target="_blank" rel="noopener">GitHub</a>
+</footer>

--- a/metro/src/app/header/header.component.css
+++ b/metro/src/app/header/header.component.css
@@ -1,0 +1,22 @@
+mat-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  gap: 8px;
+}
+
+.title {
+  font-size: 1.2rem;
+  font-weight: 500;
+  margin-left: 8px;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.status-label {
+  font-size: 0.85rem;
+  text-transform: capitalize;
+  margin-left: 4px;
+}

--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -1,1 +1,9 @@
-<h1>Metro</h1>
+<mat-toolbar color="primary">
+  <mat-icon>train</mat-icon>
+  <span class="title">Metro Madrid</span>
+  <span class="spacer"></span>
+  <ng-container *ngIf="status$ | async as s">
+    <mat-icon [style.color]="statusColor(s)">{{ statusIcon(s) }}</mat-icon>
+    <span class="status-label" [style.color]="statusColor(s)">{{ s }}</span>
+  </ng-container>
+</mat-toolbar>

--- a/metro/src/app/header/header.component.spec.ts
+++ b/metro/src/app/header/header.component.spec.ts
@@ -1,13 +1,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
 import { HeaderComponent } from './header.component';
+import { WebSocketService } from '../services/websocket.service';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
+  const mockWs = {
+    connectionStatus$: new BehaviorSubject('disconnected'),
+    messages$: new BehaviorSubject(null),
+  };
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HeaderComponent],
+      providers: [{ provide: WebSocketService, useValue: mockWs }],
+      schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
@@ -17,5 +28,21 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('statusIcon should return wifi for connected', () => {
+    expect(component.statusIcon('connected')).toBe('wifi');
+  });
+
+  it('statusIcon should return wifi_find for reconnecting', () => {
+    expect(component.statusIcon('reconnecting')).toBe('wifi_find');
+  });
+
+  it('statusIcon should return wifi_off for disconnected', () => {
+    expect(component.statusIcon('disconnected')).toBe('wifi_off');
+  });
+
+  it('statusColor should return green for connected', () => {
+    expect(component.statusColor('connected')).toBe('#4caf50');
   });
 });

--- a/metro/src/app/header/header.component.ts
+++ b/metro/src/app/header/header.component.ts
@@ -1,9 +1,28 @@
 import { Component } from '@angular/core';
+import { AsyncPipe, NgIf } from '@angular/common';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+
+import { WebSocketService, ConnectionStatus } from '../services/websocket.service';
 
 @Component({
   selector: 'app-header',
   standalone: true,
+  imports: [AsyncPipe, NgIf, MatToolbarModule, MatIconModule, MatChipsModule],
   templateUrl: './header.component.html',
-  styleUrls: ['./header.component.css']
+  styleUrls: ['./header.component.css'],
 })
-export class HeaderComponent {}
+export class HeaderComponent {
+  readonly status$ = this.ws.connectionStatus$;
+
+  constructor(private readonly ws: WebSocketService) {}
+
+  statusIcon(s: ConnectionStatus): string {
+    return s === 'connected' ? 'wifi' : s === 'reconnecting' ? 'wifi_find' : 'wifi_off';
+  }
+
+  statusColor(s: ConnectionStatus): string {
+    return s === 'connected' ? '#4caf50' : s === 'reconnecting' ? '#ff9800' : '#f44336';
+  }
+}

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -1,43 +1,186 @@
-.metro {
+.layout {
   display: flex;
-  flex-direction: column;
+  height: calc(100vh - 64px - 45px); /* minus header + footer */
+  overflow: hidden;
+  background: #121212;
+}
+
+/* Stats panel */
+.stats-panel {
+  position: relative;
+  width: 260px;
+  min-width: 260px;
+  background: #1e1e1e;
+  border-right: 1px solid #333;
+  overflow-y: auto;
+  transition: width 0.2s ease, min-width 0.2s ease;
+  flex-shrink: 0;
+}
+
+.stats-panel.collapsed {
+  width: 40px;
+  min-width: 40px;
+}
+
+.panel-toggle {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  background: #2a2a2a;
+  border: none;
+  border-bottom: 1px solid #333;
+  color: #aaa;
+  cursor: pointer;
+  padding: 8px;
+  display: flex;
+  justify-content: center;
   align-items: center;
-  background: #CCC;
-}
-
-.canvas-paths {
-  margin-top: -2000px;
-  z-index: 0;
-}
-
-.canvas-trains {
-  z-index: 2;
-}
-
-.canvas-stations {
-  margin-top: -2000px;
   z-index: 1;
 }
 
-.line-people {
+.panel-toggle:hover {
+  background: #333;
+}
+
+.panel-content {
+  padding: 12px;
   display: flex;
-  flex-wrap: wrap;
-  gap: 5px;
+  flex-direction: column;
+  gap: 12px;
 }
 
-.card {
-  width: 100px;
-  height: 100px;
-  text-align: center;
-  background: #DDD;
-  border-radius: 10px;
+.stat-card {
+  background: #2a2a2a !important;
 }
 
-.card-content {
-  border-radius: 5px;
+.clock {
+  font-size: 1.6rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  margin: 4px 0;
+  color: #90caf9;
 }
 
-.card-header {
-  text-transform: uppercase;
-  font-size: 20px;
+.multiplier {
+  font-size: 0.8rem;
+  color: #888;
+  margin: 0;
+}
+
+.stat-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 0.85rem;
+}
+
+.stat-row mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  color: #888;
+}
+
+.stat-row span {
+  flex: 1;
+  color: #bbb;
+}
+
+.stat-row strong {
+  color: #e0e0e0;
+}
+
+.line-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+}
+
+.line-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  flex-shrink: 0;
+}
+
+mat-progress-bar {
+  flex: 1;
+  height: 6px;
+  border-radius: 3px;
+}
+
+.line-count {
+  font-size: 0.75rem;
+  color: #888;
+  min-width: 30px;
+  text-align: right;
+}
+
+/* Map area */
+.map-area {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+}
+
+.canvas-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #1a1a2e;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+}
+
+.canvas-paths {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 0;
+}
+
+.canvas-stations {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 1;
+}
+
+.canvas-trains {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 2;
+}
+
+/* Responsive: collapse panel on small screens */
+@media (max-width: 768px) {
+  .stats-panel {
+    width: 40px;
+    min-width: 40px;
+  }
+
+  .stats-panel.collapsed {
+    width: 40px;
+    min-width: 40px;
+  }
+}
+
+@media (max-width: 1024px) {
+  .stats-panel {
+    width: 200px;
+    min-width: 200px;
+  }
 }

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -1,42 +1,81 @@
+<div class="layout">
 
-<div class="line-people">
-  Clock: {{displayClock()}}
-</div>
+  <!-- Stats panel (#34) -->
+  <aside class="stats-panel" [class.collapsed]="panelCollapsed">
+    <button class="panel-toggle" (click)="panelCollapsed = !panelCollapsed" title="Toggle panel">
+      <mat-icon>{{ panelCollapsed ? 'chevron_right' : 'chevron_left' }}</mat-icon>
+    </button>
 
-<div class="all-people">
-  Simulation people: {{simulationPeople}}
-</div>
+    <div class="panel-content" *ngIf="!panelCollapsed">
+      <mat-card appearance="outlined" class="stat-card">
+        <mat-card-header>
+          <mat-card-title>Simulation clock</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <p class="clock">{{ displayClock() }}</p>
+          <p class="multiplier">×{{ state.timeMultiplier }} speed</p>
+        </mat-card-content>
+      </mat-card>
 
-<div class="all-people">
-  Platforms people: {{allPeople(platformsPeople)}}
-</div>
+      <mat-card appearance="outlined" class="stat-card">
+        <mat-card-header>
+          <mat-card-title>People</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="stat-row">
+            <mat-icon>groups</mat-icon>
+            <span>Simulation</span>
+            <strong>{{ state.simulationPeople }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>subway</mat-icon>
+            <span>In metro</span>
+            <strong>{{ state.metroPeople }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>train</mat-icon>
+            <span>In trains</span>
+            <strong>{{ state.trainsPeople }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>platform</mat-icon>
+            <span>On platforms</span>
+            <strong>{{ allPeople(state.platformsPeople) }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>store</mat-icon>
+            <span>In stations</span>
+            <strong>{{ allPeople(state.stationsPeople) }}</strong>
+          </div>
+        </mat-card-content>
+      </mat-card>
 
-<div class="all-people">
-  Stations people: {{allPeople(stationsPeople)}}
-</div>
-
-<div class="all-people">
-  Trains people: {{trainsPeople}}
-</div>
-
-<div class="all-people">
-  Metro people: {{metroPeople}}
-</div>
-
-<div class="all-people">
-  Check people: {{computeCheckPeople()}}
-</div>
-
-<div class="line-people">
-  <div class="card" *ngFor="let line  of linePeople()">
-    <div class="card-content">
-      <h3 class="card-header" [style.color]="lineColors(line[0])">{{line[0]}}</h3>
-      <p class="card-info">{{line[1]}}</p>
+      <mat-card appearance="outlined" class="stat-card">
+        <mat-card-header>
+          <mat-card-title>By line</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="line-row" *ngFor="let line of linePeople()">
+            <span class="line-badge" [style.background]="lineColors(line[0])">{{ line[0] }}</span>
+            <mat-progress-bar
+              mode="determinate"
+              [value]="linePercent(line[1])"
+              [style.--mdc-linear-progress-active-indicator-color]="lineColors(line[0])">
+            </mat-progress-bar>
+            <span class="line-count">{{ line[1] }}</span>
+          </div>
+        </mat-card-content>
+      </mat-card>
     </div>
-  </div>
-</div>
-<div class="metro">
-  <canvas #canvas_trains class="canvas-trains" width="{{width}}" height="{{height}}"></canvas>
-  <canvas #canvas_stations class="canvas-stations" width="{{width}}" height="{{height}}"></canvas>
-  <canvas #canvas_paths class="canvas-paths" width="{{width}}" height="{{height}}"></canvas>
+  </aside>
+
+  <!-- Canvas map -->
+  <main class="map-area">
+    <div class="canvas-wrapper">
+      <canvas #canvas_trains class="canvas-trains" [width]="width" [height]="height"></canvas>
+      <canvas #canvas_stations class="canvas-stations" [width]="width" [height]="height"></canvas>
+      <canvas #canvas_paths class="canvas-paths" [width]="width" [height]="height"></canvas>
+    </div>
+  </main>
+
 </div>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1,7 +1,11 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
-import { NgFor } from '@angular/common';
+import { NgFor, NgIf } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
+
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 
 import Panzoom from '@panzoom/panzoom';
 
@@ -15,7 +19,7 @@ import { CANVAS_WIDTH, CANVAS_HEIGHT, REDRAW_PERIOD_MS, LINE_COLORS } from '../c
 @Component({
   selector: 'app-train',
   standalone: true,
-  imports: [NgFor],
+  imports: [NgFor, NgIf, MatCardModule, MatIconModule, MatProgressBarModule],
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css']
 })
@@ -32,6 +36,8 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   readonly width = CANVAS_WIDTH;
   readonly height = CANVAS_HEIGHT;
 
+  panelCollapsed = false;
+
   private time = 6 * 3600 * 1000;
   private lastClockAdvance = 0;
   private rafId = 0;
@@ -40,7 +46,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     private readonly wsService: WebSocketService,
-    private readonly metroData: MetroDataService,
+    readonly metroData: MetroDataService,
     readonly state: SimulationStateService,
   ) {
     const lines = new Set(this.metroData.paths.map(p => p.line));
@@ -147,14 +153,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.time += REDRAW_PERIOD_MS / this.state.timeMultiplier;
   }
 
-  // --- Template-facing helpers ---
-
-  get simulationPeople(): number { return this.state.simulationPeople; }
-  get metroPeople(): number { return this.state.metroPeople; }
-  get trainsPeople(): number { return this.state.trainsPeople; }
-  get platformsPeople(): Map<string, number> { return this.state.platformsPeople; }
-  get stationsPeople(): Map<string, number> { return this.state.stationsPeople; }
-
   displayClock(): string {
     return new Date(this.time).toLocaleTimeString('en-GB', {
       timeZone: 'Etc/UTC',
@@ -173,6 +171,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   allPeople(recipient: Map<string, number>): number {
     const values = Array.from(recipient.values());
     return values.length === 0 ? 0 : values.reduce((p, c) => p + c);
+  }
+
+  linePercent(count: number): number {
+    const max = Math.max(...Array.from(this.state.platformsPeople.values()), 1);
+    return Math.round((count / max) * 100);
   }
 
   computeCheckPeople(): number {

--- a/metro/src/styles.css
+++ b/metro/src/styles.css
@@ -1,1 +1,33 @@
-/* You can add global styles to this file, and also import other style files */
+@use '@angular/material' as mat;
+
+@include mat.core();
+
+$metro-theme: mat.define-theme((
+  color: (
+    theme-type: dark,
+    primary: mat.$azure-palette,
+    tertiary: mat.$blue-palette,
+  ),
+  typography: (
+    brand-family: 'Roboto, sans-serif',
+    plain-family: 'Roboto, sans-serif',
+  ),
+));
+
+html {
+  @include mat.all-component-themes($metro-theme);
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background-color: #121212;
+  color: #e0e0e0;
+  font-family: Roboto, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}


### PR DESCRIPTION
## Summary
- **#33**: Angular Material 21 with dark theme throughout. Header redesigned with `mat-toolbar`, connection status icon (green/amber/red). Footer with GitHub link.
- **#34**: Collapsible stats sidebar — simulation clock, speed multiplier, people counts by category, per-line progress bars coloured with line colours. Does not obstruct the map.
- **#36**: Responsive layout — panel auto-collapses at ≤768px, narrows at ≤1024px. Canvas in a flex+overflow container that works at all desktop resolutions.

## Test plan
- [ ] CI passes (38 tests)
- [ ] Dark theme visible on load, no white flash
- [ ] Header shows wifi icon changing colour as WebSocket connects/disconnects
- [ ] Stats panel shows real data when simulator is running
- [ ] Panel collapses/expands with toggle button
- [ ] Layout intact at 1920px, 1440px, 1024px, 768px