### PR TITLE
Add zoom controls to the map

### DIFF
--- a/metro/angular.json
+++ b/metro/angular.json
@@ -68,10 +68,10 @@
           "builder": "@angular-devkit/build-angular:dev-server",
           "configurations": {
             "production": {
-              "browserTarget": "metro:build:production"
+              "buildTarget": "metro:build:production"
             },
             "development": {
-              "browserTarget": "metro:build:development"
+              "buildTarget": "metro:build:development"
             }
           },
           "defaultConfiguration": "development"
@@ -79,7 +79,7 @@
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "metro:build"
+            "buildTarget": "metro:build"
           }
         },
         "test": {

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -129,8 +129,20 @@ mat-progress-bar {
   flex: 1;
   overflow: hidden;
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+  position: relative;
+}
+
+.zoom-controls {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 10;
 }
 
 .canvas-wrapper {

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -71,6 +71,11 @@
 
   <!-- Canvas map -->
   <main class="map-area">
+    <div class="zoom-controls">
+      <button mat-mini-fab color="primary" (click)="zoomIn()" title="Zoom in"><mat-icon>add</mat-icon></button>
+      <button mat-mini-fab color="primary" (click)="zoomOut()" title="Zoom out"><mat-icon>remove</mat-icon></button>
+      <button mat-mini-fab (click)="zoomReset()" title="Reset zoom"><mat-icon>center_focus_strong</mat-icon></button>
+    </div>
     <div class="canvas-wrapper">
       <canvas #canvas_trains class="canvas-trains" [width]="width" [height]="height"></canvas>
       <canvas #canvas_stations class="canvas-stations" [width]="width" [height]="height"></canvas>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -3,6 +3,7 @@ import { NgFor, NgIf } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -19,7 +20,7 @@ import { CANVAS_WIDTH, CANVAS_HEIGHT, REDRAW_PERIOD_MS, LINE_COLORS } from '../c
 @Component({
   selector: 'app-train',
   standalone: true,
-  imports: [NgFor, NgIf, MatCardModule, MatIconModule, MatProgressBarModule],
+  imports: [NgFor, NgIf, MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule],
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css']
 })
@@ -38,6 +39,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   panelCollapsed = false;
 
+  private panzoomInstances: ReturnType<typeof Panzoom>[] = [];
   private time = 6 * 3600 * 1000;
   private lastClockAdvance = 0;
   private rafId = 0;
@@ -97,9 +99,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   }
 
   private panAndZoom(): void {
-    const panzoomStations = Panzoom(this.canvasStations.nativeElement, { maxScale: 10, canvas: true, step: 0.2 });
-    const panzoom = Panzoom(this.canvasPaths.nativeElement, { maxScale: 10, canvas: true, step: 0.2 });
-    const panzoomTrains = Panzoom(this.canvasTrains.nativeElement, { maxScale: 10, canvas: true, step: 0.2 });
+    const opts = { maxScale: 10, minScale: 0.2, canvas: true, step: 0.3 };
+    const panzoomStations = Panzoom(this.canvasStations.nativeElement, opts);
+    const panzoom = Panzoom(this.canvasPaths.nativeElement, opts);
+    const panzoomTrains = Panzoom(this.canvasTrains.nativeElement, opts);
+    this.panzoomInstances = [panzoomStations, panzoom, panzoomTrains];
 
     this.canvasTrains.nativeElement.parentElement.addEventListener('wheel', (event: any) => {
       if (!event.shiftKey) return;
@@ -111,6 +115,18 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       panzoomStations.pan(pan.x, pan.y);
       panzoomTrains.pan(pan.x, pan.y);
     });
+  }
+
+  zoomIn(): void {
+    this.panzoomInstances.forEach(p => p.zoomIn());
+  }
+
+  zoomOut(): void {
+    this.panzoomInstances.forEach(p => p.zoomOut());
+  }
+
+  zoomReset(): void {
+    this.panzoomInstances.forEach(p => p.reset());
   }
 
   private drawStations(ctx: CanvasRenderingContext2D, stations: Station[]): void {


### PR DESCRIPTION
Three floating buttons (bottom-right of the canvas): zoom in, zoom out, and reset. All three panzoom instances are kept in sync. Shift+wheel still works as before. Zoom step bumped to 0.3 and minScale set to 0.2.