### PR TITLE
Simulation configuration panel (#46)

### DIFF
--- a/metro/src/app/config-dialog/config-dialog.component.css
+++ b/metro/src/app/config-dialog/config-dialog.component.css
@@ -1,0 +1,34 @@
+h2[mat-dialog-title] {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+mat-dialog-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 340px;
+  padding-top: 8px !important;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.capacity-summary {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: rgba(144, 202, 249, 0.1);
+  border-radius: 4px;
+  font-size: 0.9rem;
+  color: #90caf9;
+}
+
+.capacity-summary mat-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+}

--- a/metro/src/app/config-dialog/config-dialog.component.html
+++ b/metro/src/app/config-dialog/config-dialog.component.html
@@ -1,0 +1,36 @@
+<h2 mat-dialog-title>
+  <mat-icon>settings</mat-icon>
+  Simulation configuration
+</h2>
+
+<mat-dialog-content [formGroup]="form">
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Wagon capacity (people per wagon)</mat-label>
+    <input matInput type="number" formControlName="wagonCapacity" min="1" max="500">
+    <mat-error *ngIf="form.get('wagonCapacity')?.invalid">Enter a value between 1 and 500</mat-error>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Wagons per train</mat-label>
+    <input matInput type="number" formControlName="wagonsPerTrain" min="1" max="20">
+    <mat-error *ngIf="form.get('wagonsPerTrain')?.invalid">Enter a value between 1 and 20</mat-error>
+  </mat-form-field>
+
+  <mat-form-field appearance="outline" class="full-width">
+    <mat-label>Trains per quarter hour (per line)</mat-label>
+    <input matInput type="number" formControlName="trainsPerQuarterHour" min="1" max="30">
+    <mat-error *ngIf="form.get('trainsPerQuarterHour')?.invalid">Enter a value between 1 and 30</mat-error>
+  </mat-form-field>
+
+  <div class="capacity-summary" *ngIf="form.valid">
+    <mat-icon>info</mat-icon>
+    Effective train capacity: <strong>{{ trainCapacity }} people</strong>
+  </div>
+
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="cancel()">Cancel</button>
+  <button mat-flat-button color="primary" [disabled]="form.invalid" (click)="apply()">Apply</button>
+</mat-dialog-actions>

--- a/metro/src/app/config-dialog/config-dialog.component.html
+++ b/metro/src/app/config-dialog/config-dialog.component.html
@@ -8,25 +8,33 @@
   <mat-form-field appearance="outline" class="full-width">
     <mat-label>Wagon capacity (people per wagon)</mat-label>
     <input matInput type="number" formControlName="wagonCapacity" min="1" max="500">
-    <mat-error *ngIf="form.get('wagonCapacity')?.invalid">Enter a value between 1 and 500</mat-error>
+    @if (form.get('wagonCapacity')?.invalid) {
+      <mat-error>Enter a value between 1 and 500</mat-error>
+    }
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
     <mat-label>Wagons per train</mat-label>
     <input matInput type="number" formControlName="wagonsPerTrain" min="1" max="20">
-    <mat-error *ngIf="form.get('wagonsPerTrain')?.invalid">Enter a value between 1 and 20</mat-error>
+    @if (form.get('wagonsPerTrain')?.invalid) {
+      <mat-error>Enter a value between 1 and 20</mat-error>
+    }
   </mat-form-field>
 
   <mat-form-field appearance="outline" class="full-width">
     <mat-label>Trains per quarter hour (per line)</mat-label>
     <input matInput type="number" formControlName="trainsPerQuarterHour" min="1" max="30">
-    <mat-error *ngIf="form.get('trainsPerQuarterHour')?.invalid">Enter a value between 1 and 30</mat-error>
+    @if (form.get('trainsPerQuarterHour')?.invalid) {
+      <mat-error>Enter a value between 1 and 30</mat-error>
+    }
   </mat-form-field>
 
-  <div class="capacity-summary" *ngIf="form.valid">
+  @if (form.valid) {
+  <div class="capacity-summary">
     <mat-icon>info</mat-icon>
     Effective train capacity: <strong>{{ trainCapacity }} people</strong>
   </div>
+  }
 
 </mat-dialog-content>
 

--- a/metro/src/app/config-dialog/config-dialog.component.ts
+++ b/metro/src/app/config-dialog/config-dialog.component.ts
@@ -1,0 +1,54 @@
+import { Component } from '@angular/core';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+import { SimulationConfigService } from '../services/simulation-config.service';
+
+@Component({
+  selector: 'app-config-dialog',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+  ],
+  templateUrl: './config-dialog.component.html',
+  styleUrls: ['./config-dialog.component.css'],
+})
+export class ConfigDialogComponent {
+
+  readonly form = this.fb.group({
+    wagonCapacity:       [this.cfg.config.wagonCapacity,       [Validators.required, Validators.min(1), Validators.max(500)]],
+    wagonsPerTrain:      [this.cfg.config.wagonsPerTrain,      [Validators.required, Validators.min(1), Validators.max(20)]],
+    trainsPerQuarterHour:[this.cfg.config.trainsPerQuarterHour,[Validators.required, Validators.min(1), Validators.max(30)]],
+  });
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly cfg: SimulationConfigService,
+    private readonly dialogRef: MatDialogRef<ConfigDialogComponent>,
+  ) {}
+
+  get trainCapacity(): number {
+    const cap = this.form.value.wagonCapacity ?? 0;
+    const wagons = this.form.value.wagonsPerTrain ?? 0;
+    return cap * wagons;
+  }
+
+  apply(): void {
+    if (this.form.invalid) return;
+    this.cfg.save(this.form.value as any);
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -6,4 +6,7 @@
     <mat-icon [style.color]="statusColor(s)">{{ statusIcon(s) }}</mat-icon>
     <span class="status-label" [style.color]="statusColor(s)">{{ s }}</span>
   </ng-container>
+  <button mat-icon-button (click)="openConfig()" title="Simulation settings">
+    <mat-icon>settings</mat-icon>
+  </button>
 </mat-toolbar>

--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -2,10 +2,10 @@
   <mat-icon>train</mat-icon>
   <span class="title">Metro Madrid</span>
   <span class="spacer"></span>
-  <ng-container *ngIf="status$ | async as s">
+  @if (status$ | async; as s) {
     <mat-icon [style.color]="statusColor(s)">{{ statusIcon(s) }}</mat-icon>
     <span class="status-label" [style.color]="statusColor(s)">{{ s }}</span>
-  </ng-container>
+  }
   <button mat-icon-button (click)="openConfig()" title="Simulation settings">
     <mat-icon>settings</mat-icon>
   </button>

--- a/metro/src/app/header/header.component.ts
+++ b/metro/src/app/header/header.component.ts
@@ -2,21 +2,30 @@ import { Component } from '@angular/core';
 import { AsyncPipe, NgIf } from '@angular/common';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
-import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialog } from '@angular/material/dialog';
 
 import { WebSocketService, ConnectionStatus } from '../services/websocket.service';
+import { ConfigDialogComponent } from '../config-dialog/config-dialog.component';
 
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [AsyncPipe, NgIf, MatToolbarModule, MatIconModule, MatChipsModule],
+  imports: [AsyncPipe, NgIf, MatToolbarModule, MatIconModule, MatButtonModule],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css'],
 })
 export class HeaderComponent {
   readonly status$ = this.ws.connectionStatus$;
 
-  constructor(private readonly ws: WebSocketService) {}
+  constructor(
+    private readonly ws: WebSocketService,
+    private readonly dialog: MatDialog,
+  ) {}
+
+  openConfig(): void {
+    this.dialog.open(ConfigDialogComponent, { width: '420px' });
+  }
 
   statusIcon(s: ConnectionStatus): string {
     return s === 'connected' ? 'wifi' : s === 'reconnecting' ? 'wifi_find' : 'wifi_off';

--- a/metro/src/app/header/header.component.ts
+++ b/metro/src/app/header/header.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { AsyncPipe, NgIf } from '@angular/common';
+import { AsyncPipe } from '@angular/common';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -11,7 +11,7 @@ import { ConfigDialogComponent } from '../config-dialog/config-dialog.component'
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [AsyncPipe, NgIf, MatToolbarModule, MatIconModule, MatButtonModule],
+  imports: [AsyncPipe, MatToolbarModule, MatIconModule, MatButtonModule],
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.css'],
 })

--- a/metro/src/app/services/simulation-config.service.spec.ts
+++ b/metro/src/app/services/simulation-config.service.spec.ts
@@ -1,0 +1,43 @@
+import { TestBed } from '@angular/core/testing';
+import { SimulationConfigService } from './simulation-config.service';
+
+describe('SimulationConfigService', () => {
+  let service: SimulationConfigService;
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SimulationConfigService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return defaults when localStorage is empty', () => {
+    expect(service.config.wagonCapacity).toBe(100);
+    expect(service.config.wagonsPerTrain).toBe(6);
+    expect(service.config.trainsPerQuarterHour).toBe(4);
+  });
+
+  it('trainCapacity should be wagonCapacity × wagonsPerTrain', () => {
+    expect(service.trainCapacity).toBe(600);
+  });
+
+  it('save should update config and persist to localStorage', () => {
+    service.save({ wagonCapacity: 80, wagonsPerTrain: 8, trainsPerQuarterHour: 6 });
+    expect(service.config.wagonCapacity).toBe(80);
+    expect(service.trainCapacity).toBe(640);
+    const stored = JSON.parse(localStorage.getItem('metro_sim_config')!);
+    expect(stored.wagonsPerTrain).toBe(8);
+  });
+
+  it('should restore config from localStorage on init', () => {
+    localStorage.setItem('metro_sim_config', JSON.stringify({ wagonCapacity: 50, wagonsPerTrain: 4, trainsPerQuarterHour: 3 }));
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({});
+    const restored = TestBed.inject(SimulationConfigService);
+    expect(restored.config.wagonCapacity).toBe(50);
+    expect(restored.config.wagonsPerTrain).toBe(4);
+  });
+});

--- a/metro/src/app/services/simulation-config.service.ts
+++ b/metro/src/app/services/simulation-config.service.ts
@@ -1,0 +1,45 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+export interface SimulationConfig {
+  wagonCapacity: number;
+  wagonsPerTrain: number;
+  trainsPerQuarterHour: number;
+}
+
+const STORAGE_KEY = 'metro_sim_config';
+
+const DEFAULT_CONFIG: SimulationConfig = {
+  wagonCapacity: 100,
+  wagonsPerTrain: 6,
+  trainsPerQuarterHour: 4,
+};
+
+@Injectable({ providedIn: 'root' })
+export class SimulationConfigService {
+
+  private readonly _config$ = new BehaviorSubject<SimulationConfig>(this.load());
+  readonly config$ = this._config$.asObservable();
+
+  get config(): SimulationConfig {
+    return this._config$.value;
+  }
+
+  get trainCapacity(): number {
+    const c = this._config$.value;
+    return c.wagonCapacity * c.wagonsPerTrain;
+  }
+
+  save(config: SimulationConfig): void {
+    this._config$.next(config);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+  }
+
+  private load(): SimulationConfig {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return { ...DEFAULT_CONFIG, ...JSON.parse(raw) };
+    } catch { /* ignore */ }
+    return { ...DEFAULT_CONFIG };
+  }
+}

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -52,6 +52,34 @@
 
       <mat-card appearance="outlined" class="stat-card">
         <mat-card-header>
+          <mat-card-title>Train config</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="stat-row">
+            <mat-icon>airline_seat_recline_normal</mat-icon>
+            <span>Wagon capacity</span>
+            <strong>{{ cfg.config.wagonCapacity }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>view_week</mat-icon>
+            <span>Wagons/train</span>
+            <strong>{{ cfg.config.wagonsPerTrain }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>schedule</mat-icon>
+            <span>Trains/15 min</span>
+            <strong>{{ cfg.config.trainsPerQuarterHour }}</strong>
+          </div>
+          <div class="stat-row">
+            <mat-icon>people</mat-icon>
+            <span>Train capacity</span>
+            <strong>{{ cfg.trainCapacity }}</strong>
+          </div>
+        </mat-card-content>
+      </mat-card>
+
+      <mat-card appearance="outlined" class="stat-card">
+        <mat-card-header>
           <mat-card-title>By line</mat-card-title>
         </mat-card-header>
         <mat-card-content>

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -6,7 +6,8 @@
       <mat-icon>{{ panelCollapsed ? 'chevron_right' : 'chevron_left' }}</mat-icon>
     </button>
 
-    <div class="panel-content" *ngIf="!panelCollapsed">
+    @if (!panelCollapsed) {
+    <div class="panel-content">
       <mat-card appearance="outlined" class="stat-card">
         <mat-card-header>
           <mat-card-title>Simulation clock</mat-card-title>
@@ -83,7 +84,8 @@
           <mat-card-title>By line</mat-card-title>
         </mat-card-header>
         <mat-card-content>
-          <div class="line-row" *ngFor="let line of linePeople()">
+          @for (line of linePeople(); track line[0]) {
+          <div class="line-row">
             <span class="line-badge" [style.background]="lineColors(line[0])">{{ line[0] }}</span>
             <mat-progress-bar
               mode="determinate"
@@ -92,9 +94,11 @@
             </mat-progress-bar>
             <span class="line-count">{{ line[1] }}</span>
           </div>
+          }
         </mat-card-content>
       </mat-card>
     </div>
+    }
   </aside>
 
   <!-- Canvas map -->

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1,5 +1,4 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
-import { NgFor, NgIf } from '@angular/common';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -21,7 +20,7 @@ import { CANVAS_WIDTH, CANVAS_HEIGHT, REDRAW_PERIOD_MS, LINE_COLORS } from '../c
 @Component({
   selector: 'app-train',
   standalone: true,
-  imports: [NgFor, NgIf, MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule],
+  imports: [MatButtonModule, MatCardModule, MatIconModule, MatProgressBarModule],
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css']
 })

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -13,6 +13,7 @@ import Panzoom from '@panzoom/panzoom';
 import { WebSocketService } from '../services/websocket.service';
 import { MetroDataService } from '../services/metro-data.service';
 import { SimulationStateService } from '../services/simulation-state.service';
+import { SimulationConfigService } from '../services/simulation-config.service';
 import { Station } from '../station';
 import { Train } from '../train';
 import { CANVAS_WIDTH, CANVAS_HEIGHT, REDRAW_PERIOD_MS, LINE_COLORS } from '../constants';
@@ -50,6 +51,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     private readonly wsService: WebSocketService,
     readonly metroData: MetroDataService,
     readonly state: SimulationStateService,
+    readonly cfg: SimulationConfigService,
   ) {
     const lines = new Set(this.metroData.paths.map(p => p.line));
     this.state.initLines(Array.from(lines));

--- a/metro/src/main.ts
+++ b/metro/src/main.ts
@@ -1,13 +1,14 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 
 import { AppComponent } from './app/app.component';
-import { environment } from './environments/environment';
 
 bootstrapApplication(AppComponent, {
   providers: [
     provideRouter([]),
     provideHttpClient(),
+    provideAnimations(),
   ],
 }).catch(err => console.error(err));


### PR DESCRIPTION
## Summary
Closes #46. Adds a configuration dialog to set simulation parameters without touching code.

## What's new

**`SimulationConfigService`**
- Stores `wagonCapacity`, `wagonsPerTrain`, `trainsPerQuarterHour`
- Persists to `localStorage` — survives page reloads
- Exposes `trainCapacity` getter (wagon × wagons)
- Defaults: 100 people/wagon, 6 wagons/train, 4 trains/15 min → 600 people/train

**`ConfigDialogComponent`**
- Opened via the ⚙ button in the header toolbar
- Reactive form with validation (ranges enforced, Apply disabled when invalid)
- Live preview of effective train capacity while editing

**Stats panel**
- New "Train config" card shows current params + effective train capacity

## Test plan
- [ ] CI passes (43 tests)
- [ ] ⚙ button in header opens dialog
- [ ] Values pre-filled from last saved config
- [ ] Apply saves and reflects in stats panel
- [ ] Invalid values (0, letters) disable Apply and show error
- [ ] Config survives page reload