### PR TITLE
feat: semantic zoom for canvas rendering

### DIFF
--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -34,8 +34,6 @@
   top: 0;
   left: 0;
   display: block;
-  /* Scale the 3400×2000 canvas to fit inside the viewport */
-  transform-origin: top left;
 }
 
 /* ── Floating stats panel ─────────────────────────────────── */

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -195,6 +195,23 @@
   flex-shrink: 0;
 }
 
+/* ── Zoom indicator (dev only) ───────────────────────────── */
+.zoom-indicator {
+  position: absolute;
+  bottom: 148px;
+  right: 12px;
+  background: rgba(13, 17, 23, 0.92);
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 600;
+  color: #f0b429;
+  letter-spacing: 0.05em;
+  z-index: 20;
+  pointer-events: none;
+}
+
 /* ── Zoom bar ─────────────────────────────────────────────── */
 .zoom-bar {
   position: absolute;

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -2,9 +2,9 @@
 
   <!-- Canvas layers -->
   <div class="canvas-container" #canvasContainer>
-    <canvas #canvas_paths   class="canvas-layer" [width]="width" [height]="height"></canvas>
-    <canvas #canvas_stations class="canvas-layer" [width]="width" [height]="height"></canvas>
-    <canvas #canvas_trains  class="canvas-layer" [width]="width" [height]="height"></canvas>
+    <canvas #canvas_paths    class="canvas-layer"></canvas>
+    <canvas #canvas_stations class="canvas-layer"></canvas>
+    <canvas #canvas_trains   class="canvas-layer"></canvas>
   </div>
 
   <!-- Stats panel (floating) -->

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -94,6 +94,11 @@
     }
   </aside>
 
+  <!-- Zoom indicator (dev only) -->
+  @if (isDev) {
+    <div class="zoom-indicator">×{{ (currentScale / fitScale).toFixed(2) }}</div>
+  }
+
   <!-- Zoom controls -->
   <div class="zoom-bar">
     <button class="zoom-btn" (click)="zoomIn()"    title="Zoom in">

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -56,9 +56,8 @@ describe('TrainComponent', () => {
     expect(mockSimulationStateService.initLines).toHaveBeenCalled();
   });
 
-  it('should expose canvas dimensions', () => {
-    expect(component.width).toBeGreaterThan(0);
-    expect(component.height).toBeGreaterThan(0);
+  it('should initialize with a valid fit scale', () => {
+    expect(component.currentScale).toBeGreaterThan(0);
   });
 
   it('displayClock should return a time string', () => {

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1,4 +1,5 @@
 import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy } from '@angular/core';
+import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
@@ -36,6 +37,13 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   panelCollapsed = false;
 
   private panzoomInstances: ReturnType<typeof Panzoom>[] = [];
+  currentScale = 1;
+  protected fitScale = 1;
+  // Labels visible at fit zoom (pre-computed once, stable across zoom changes)
+  private labelVisible: boolean[] = [];
+  // Above this zoom multiplier, show all labels (viewport is small enough)
+  private static readonly LABEL_SHOW_ALL_ZOOM = 2.5;
+  readonly isDev = !environment.production;
   private time = 6 * 3600 * 1000;
   private lastClockAdvance = 0;
   private rafId = 0;
@@ -52,15 +60,27 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.state.initLines(Array.from(lines));
   }
 
+  private setupCanvas(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width  = CANVAS_WIDTH  * dpr;
+    canvas.height = CANVAS_HEIGHT * dpr;
+    canvas.style.width  = `${CANVAS_WIDTH}px`;
+    canvas.style.height = `${CANVAS_HEIGHT}px`;
+    const ctx = canvas.getContext('2d')!;
+    ctx.scale(dpr, dpr);
+    return ctx;
+  }
+
   ngAfterViewInit(): void {
-    this.ctxStations = this.canvasStations.nativeElement.getContext('2d');
-    this.ctx = this.canvasPaths.nativeElement.getContext('2d');
-    this.ctxTrains = this.canvasTrains.nativeElement.getContext('2d');
+    this.ctxStations = this.setupCanvas(this.canvasStations.nativeElement);
+    this.ctx         = this.setupCanvas(this.canvasPaths.nativeElement);
+    this.ctxTrains   = this.setupCanvas(this.canvasTrains.nativeElement);
     this.ctxTrains.fillStyle = 'red';
 
-    this.drawPaths(this.ctx, this.metroData.paths);
-    this.drawStations(this.ctxStations, this.metroData.stations);
     this.panAndZoom();
+    this.computeLabelVisibility();
+    this.drawPaths(this.ctx, this.metroData.paths, this.currentScale);
+    this.drawStations(this.ctxStations, this.metroData.stations, this.currentScale);
 
     this.wsService.messages$
       .pipe(takeUntil(this.destroy$))
@@ -118,7 +138,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     ];
     this.panzoomInstances = [driver, ...followers];
 
-    // Mirror every pan/zoom from driver to followers
+    this.currentScale = fitScale;
+    this.fitScale = fitScale;
+
+    // Mirror every pan/zoom from driver to followers; redraw static layers on zoom
     const sync = (e: any) => {
       const { x, y, scale } = e.detail;
       followers.forEach(f => {
@@ -126,8 +149,18 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         f.pan(x, y, { animate: false });
       });
     };
+    const syncAndRedraw = (e: any) => {
+      const { x, y, scale } = e.detail;
+      this.currentScale = scale;
+      followers.forEach(f => {
+        f.zoom(scale, { animate: false });
+        f.pan(x, y, { animate: false });
+      });
+      this.drawPaths(this.ctx, this.metroData.paths, scale);
+      this.drawStations(this.ctxStations, this.metroData.stations, scale);
+    };
     this.canvasTrains.nativeElement.addEventListener('panzoompan',  sync);
-    this.canvasTrains.nativeElement.addEventListener('panzoomzoom', sync);
+    this.canvasTrains.nativeElement.addEventListener('panzoomzoom', syncAndRedraw);
 
     // Wheel zoom (driver handles it; sync fires automatically via events above)
     container.addEventListener('wheel', (event: any) => {
@@ -154,24 +187,91 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.panzoomInstances.forEach(p => p.pan(x, y, { animate: true }));
   }
 
-  private drawStations(ctx: CanvasRenderingContext2D, stations: Station[]): void {
-    ctx.font = '8px Verdana';
-    ctx.fillStyle = 'white';
-    ctx.strokeStyle = 'white';
-    for (const station of stations) {
-      ctx.fillText(station.name, station.position.x + 7, station.position.y + 3);
+  // Target visual sizes in CSS pixels (independent of zoom)
+  private static readonly DOT_RADIUS_PX   = 5;   // station dot radius on screen
+  private static readonly DOT_STROKE_PX   = 1.2;
+  private static readonly LABEL_SIZE_PX      = 11;  // font size on screen (low zoom)
+  private static readonly LABEL_SIZE_ZOOM_PX = 13;  // font size on screen (high zoom / show-all)
+  private static readonly LABEL_MIN_SCALE    = 0.35; // hide labels below this zoom
+
+  // Responsive line width: ~6px on a 1200px-wide container, scales with viewport
+  private get pathWidthPx(): number {
+    const w = (this.canvasContainer.nativeElement as HTMLElement).clientWidth;
+    return Math.max(4, Math.min(8, w / 200));
+  }
+
+  // Pre-compute which labels to show at fitScale (stable set across all zoom levels).
+  private computeLabelVisibility(): void {
+    const scale = this.fitScale;
+    const fontSize = Math.round(TrainComponent.LABEL_SIZE_PX / scale);
+    this.ctxStations.font = `${fontSize}px Inter, Verdana, sans-serif`;
+    const r       = TrainComponent.DOT_RADIUS_PX / scale;
+    const padding = 2 / scale;
+    const placed: { x: number; y: number; w: number; h: number }[] = [];
+
+    this.labelVisible = this.metroData.stations.map(station => {
+      const { x, y } = station.position;
+      const lx = x + r + padding;
+      const ly = y + fontSize * 0.35;
+      const bw = this.ctxStations.measureText(station.name).width + padding * 2;
+      const bh = fontSize * 1.1;
+      const bx = lx - padding;
+      const by = ly - fontSize * 0.85;
+      const overlaps = placed.some(p =>
+        bx < p.x + p.w && bx + bw > p.x && by < p.y + p.h && by + bh > p.y
+      );
+      if (!overlaps) { placed.push({ x: bx, y: by, w: bw, h: bh }); }
+      return !overlaps;
+    });
+  }
+
+  private drawStations(ctx: CanvasRenderingContext2D, stations: Station[], scale: number): void {
+    ctx.clearRect(0, 0, this.width, this.height);
+    const r   = TrainComponent.DOT_RADIUS_PX / scale;
+    const lw  = TrainComponent.DOT_STROKE_PX / scale;
+    const showLabels = scale >= TrainComponent.LABEL_MIN_SCALE;
+    // At high zoom the viewport shows only a small area, so show all labels
+    const showAll = (scale / this.fitScale) >= TrainComponent.LABEL_SHOW_ALL_ZOOM;
+    const targetPx = showAll ? TrainComponent.LABEL_SIZE_ZOOM_PX : TrainComponent.LABEL_SIZE_PX;
+    const fontSize = Math.round(targetPx / scale);
+
+    ctx.fillStyle   = 'white';
+    ctx.strokeStyle = '#0d1117';
+    ctx.lineWidth   = lw;
+    if (showLabels) {
+      ctx.font = `${fontSize}px Inter, Verdana, sans-serif`;
+    }
+
+    stations.forEach((station, i) => {
+      const { x, y } = station.position;
+      // Dot
       ctx.beginPath();
-      ctx.lineWidth = 1.5;
-      ctx.arc(station.position.x, station.position.y, 5, 0, Math.PI * 2, true);
+      ctx.arc(x, y, r, 0, Math.PI * 2);
       ctx.fill();
       ctx.stroke();
       ctx.closePath();
-    }
+      // Label: use pre-computed visibility or show all at high zoom
+      if (showLabels && (showAll || this.labelVisible[i])) {
+        const padding = 2 / scale;
+        const lx = x + r + padding;
+        const ly = y + fontSize * 0.35;
+        const bw = ctx.measureText(station.name).width + padding * 2;
+        const bh = fontSize * 1.1;
+        ctx.fillStyle = '#0d1117';
+        ctx.fillRect(lx - padding, ly - fontSize * 0.85, bw, bh);
+        ctx.fillStyle = 'white';
+        ctx.fillText(station.name, lx, ly);
+      }
+    });
   }
 
-  private drawPaths(ctx: CanvasRenderingContext2D, stations: Station[]): void {
+  private drawPaths(ctx: CanvasRenderingContext2D, stations: Station[], scale: number): void {
+    ctx.clearRect(0, 0, this.width, this.height);
+    ctx.lineWidth  = this.pathWidthPx / scale;
+    ctx.lineJoin   = 'round';
+    ctx.lineCap    = 'round';
     for (const station of stations) {
-      ctx.lineWidth = 6;
+      if (station.path.length < 2) continue;
       ctx.beginPath();
       ctx.moveTo(station.path[0].x, station.path[0].y);
       for (const p of station.path.slice(1)) {

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -3,15 +3,11 @@ import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import Panzoom from '@panzoom/panzoom';
-
 import { WebSocketService } from '../services/websocket.service';
 import { MetroDataService } from '../services/metro-data.service';
 import { SimulationStateService } from '../services/simulation-state.service';
 import { SimulationConfigService } from '../services/simulation-config.service';
-import { Station } from '../station';
-import { Train } from '../train';
-import { CANVAS_WIDTH, CANVAS_HEIGHT, REDRAW_PERIOD_MS, LINE_COLORS } from '../constants';
+import { REDRAW_PERIOD_MS, LINE_COLORS } from '../constants';
 
 @Component({
   selector: 'app-train',
@@ -24,31 +20,44 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   @ViewChild('canvasContainer', { static: false, read: ElementRef }) canvasContainer!: ElementRef;
   @ViewChild('canvas_stations', { static: false, read: ElementRef }) canvasStations!: ElementRef;
-  @ViewChild('canvas_paths', { static: false, read: ElementRef }) canvasPaths!: ElementRef;
-  @ViewChild('canvas_trains', { static: false, read: ElementRef }) canvasTrains!: ElementRef;
+  @ViewChild('canvas_paths',    { static: false, read: ElementRef }) canvasPaths!: ElementRef;
+  @ViewChild('canvas_trains',   { static: false, read: ElementRef }) canvasTrains!: ElementRef;
 
   private ctxStations!: CanvasRenderingContext2D;
-  private ctx!: CanvasRenderingContext2D;
+  private ctxPaths!: CanvasRenderingContext2D;
   private ctxTrains!: CanvasRenderingContext2D;
-
-  readonly width = CANVAS_WIDTH;
-  readonly height = CANVAS_HEIGHT;
 
   panelCollapsed = false;
 
-  private panzoomInstances: ReturnType<typeof Panzoom>[] = [];
+  // Zoom state — exposed to template for the dev indicator
   currentScale = 1;
-  protected fitScale = 1;
-  // Labels visible at fit zoom (pre-computed once, stable across zoom changes)
-  private labelVisible: boolean[] = [];
-  // Above this zoom multiplier, show all labels (viewport is small enough)
-  private static readonly LABEL_SHOW_ALL_ZOOM = 2.5;
+  protected fitScale  = 1;
   readonly isDev = !environment.production;
+
+  // Pan state (screen pixels: where world origin maps to)
+  private panX = 0;
+  private panY = 0;
+
+  private readonly dpr = window.devicePixelRatio || 1;
+
   private time = 6 * 3600 * 1000;
   private lastClockAdvance = 0;
   private rafId = 0;
+  private needsStaticRedraw = false;
+  private needsTrainRedraw  = false;
   private readonly destroy$ = new Subject<void>();
   private destroyed = false;
+
+  // Label visibility pre-computed at fitScale — stable set across all zoom levels
+  private labelVisible: boolean[] = [];
+
+  // Fixed screen-pixel sizes (divide by currentScale when drawing in world coords)
+  private static readonly PATH_WIDTH_PX      = 6;
+  private static readonly DOT_RADIUS_PX      = 5;
+  private static readonly DOT_STROKE_PX      = 1.2;
+  private static readonly LABEL_SIZE_PX      = 11;   // low-zoom target (screen px)
+  private static readonly LABEL_SIZE_ZOOM_PX = 13;   // high-zoom target (screen px)
+  private static readonly LABEL_SHOW_ALL_MUL = 2.5;  // show all labels above this zoom multiplier
 
   constructor(
     private readonly wsService: WebSocketService,
@@ -60,27 +69,19 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.state.initLines(Array.from(lines));
   }
 
-  private setupCanvas(canvas: HTMLCanvasElement): CanvasRenderingContext2D {
-    const dpr = window.devicePixelRatio || 1;
-    canvas.width  = CANVAS_WIDTH  * dpr;
-    canvas.height = CANVAS_HEIGHT * dpr;
-    canvas.style.width  = `${CANVAS_WIDTH}px`;
-    canvas.style.height = `${CANVAS_HEIGHT}px`;
-    const ctx = canvas.getContext('2d')!;
-    ctx.scale(dpr, dpr);
-    return ctx;
-  }
-
   ngAfterViewInit(): void {
-    this.ctxStations = this.setupCanvas(this.canvasStations.nativeElement);
-    this.ctx         = this.setupCanvas(this.canvasPaths.nativeElement);
-    this.ctxTrains   = this.setupCanvas(this.canvasTrains.nativeElement);
-    this.ctxTrains.fillStyle = 'red';
+    this.resizeCanvases();
 
-    this.panAndZoom();
+    this.ctxStations = this.canvasStations.nativeElement.getContext('2d')!;
+    this.ctxPaths    = this.canvasPaths.nativeElement.getContext('2d')!;
+    this.ctxTrains   = this.canvasTrains.nativeElement.getContext('2d')!;
+
+    this.computeFit();
     this.computeLabelVisibility();
-    this.drawPaths(this.ctx, this.metroData.paths, this.currentScale);
-    this.drawStations(this.ctxStations, this.metroData.stations, this.currentScale);
+    this.setupEvents();
+
+    this.needsStaticRedraw = true;
+    this.needsTrainRedraw  = true;
 
     this.wsService.messages$
       .pipe(takeUntil(this.destroy$))
@@ -96,13 +97,156 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.destroy$.complete();
   }
 
+  // ── Canvas sizing ────────────────────────────────────────────
+
+  private resizeCanvases(): void {
+    const el = this.canvasContainer.nativeElement as HTMLElement;
+    const W  = el.clientWidth;
+    const H  = el.clientHeight;
+    for (const ref of [this.canvasPaths, this.canvasStations, this.canvasTrains]) {
+      const c = ref.nativeElement as HTMLCanvasElement;
+      c.width  = W * this.dpr;
+      c.height = H * this.dpr;
+      c.style.width  = `${W}px`;
+      c.style.height = `${H}px`;
+    }
+  }
+
+  // ── Fit computation ──────────────────────────────────────────
+
+  private computeFit(): void {
+    const container = this.canvasContainer.nativeElement as HTMLElement;
+    const vW = container.clientWidth;
+    const vH = container.clientHeight;
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+    for (const s of this.metroData.paths) {
+      for (const p of s.path) {
+        if (p.x < minX) minX = p.x;
+        if (p.y < minY) minY = p.y;
+        if (p.x > maxX) maxX = p.x;
+        if (p.y > maxY) maxY = p.y;
+      }
+    }
+
+    const margin = 40; // screen px padding around the network
+    const netW   = maxX - minX;
+    const netH   = maxY - minY;
+    this.fitScale    = Math.min((vW - margin * 2) / netW, (vH - margin * 2) / netH);
+    this.currentScale = this.fitScale;
+    this.panX = (vW - netW * this.fitScale) / 2 - minX * this.fitScale;
+    this.panY = (vH - netH * this.fitScale) / 2 - minY * this.fitScale;
+  }
+
+  // ── Transform helpers ────────────────────────────────────────
+
+  // Sets the ctx transform so world coords → physical canvas pixels
+  private applyTransform(ctx: CanvasRenderingContext2D): void {
+    ctx.setTransform(
+      this.currentScale * this.dpr, 0,
+      0, this.currentScale * this.dpr,
+      this.panX * this.dpr,
+      this.panY * this.dpr,
+    );
+  }
+
+  // Clears the entire physical canvas (ignores current transform)
+  private clearCtx(ctx: CanvasRenderingContext2D): void {
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+  }
+
+  // ── Events ───────────────────────────────────────────────────
+
+  private setupEvents(): void {
+    const container = this.canvasContainer.nativeElement as HTMLElement;
+
+    // Wheel: zoom toward cursor
+    container.addEventListener('wheel', (e: WheelEvent) => {
+      e.preventDefault();
+      const factor    = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+      const newScale  = Math.max(
+        this.fitScale * 0.5,
+        Math.min(this.fitScale * 30, this.currentScale * factor),
+      );
+      const actual = newScale / this.currentScale;
+      this.panX = e.clientX + (this.panX - e.clientX) * actual;
+      this.panY = e.clientY + (this.panY - e.clientY) * actual;
+      this.currentScale = newScale;
+      this.needsStaticRedraw = true;
+      this.needsTrainRedraw  = true;
+    }, { passive: false });
+
+    // Mouse drag: pan
+    let dragging = false;
+    let lastX = 0, lastY = 0;
+    container.addEventListener('mousedown', (e: MouseEvent) => {
+      dragging = true; lastX = e.clientX; lastY = e.clientY;
+      container.style.cursor = 'grabbing';
+    });
+    container.addEventListener('mousemove', (e: MouseEvent) => {
+      if (!dragging) return;
+      this.panX += e.clientX - lastX;
+      this.panY += e.clientY - lastY;
+      lastX = e.clientX; lastY = e.clientY;
+      this.needsStaticRedraw = true;
+      this.needsTrainRedraw  = true;
+    });
+    const endDrag = () => { dragging = false; container.style.cursor = 'grab'; };
+    container.addEventListener('mouseup',    endDrag);
+    container.addEventListener('mouseleave', endDrag);
+
+    // Window resize: resize canvases and redraw
+    window.addEventListener('resize', () => {
+      this.resizeCanvases();
+      this.needsStaticRedraw = true;
+      this.needsTrainRedraw  = true;
+    });
+  }
+
+  // ── Zoom controls ────────────────────────────────────────────
+
+  zoomIn(): void  { this.zoomAroundCenter(1.3); }
+  zoomOut(): void { this.zoomAroundCenter(1 / 1.3); }
+
+  zoomReset(): void {
+    this.computeFit();
+    this.needsStaticRedraw = true;
+    this.needsTrainRedraw  = true;
+  }
+
+  private zoomAroundCenter(factor: number): void {
+    const el = this.canvasContainer.nativeElement as HTMLElement;
+    const cx = el.clientWidth  / 2;
+    const cy = el.clientHeight / 2;
+    const newScale = Math.max(
+      this.fitScale * 0.5,
+      Math.min(this.fitScale * 30, this.currentScale * factor),
+    );
+    const actual = newScale / this.currentScale;
+    this.panX = cx + (this.panX - cx) * actual;
+    this.panY = cy + (this.panY - cy) * actual;
+    this.currentScale = newScale;
+    this.needsStaticRedraw = true;
+    this.needsTrainRedraw  = true;
+  }
+
+  // ── Render loop ──────────────────────────────────────────────
+
   private startRenderLoop(): void {
     const loop = (timestamp: number) => {
       if (this.destroyed) return;
 
-      if (this.state.dirty) {
-        this.drawTrains(this.state.trains);
-        this.state.dirty = false;
+      if (this.needsStaticRedraw) {
+        this.drawPaths();
+        this.drawStations();
+        this.needsStaticRedraw = false;
+      }
+
+      if (this.state.dirty || this.needsTrainRedraw) {
+        this.drawTrains();
+        this.state.dirty      = false;
+        this.needsTrainRedraw = false;
       }
 
       if (timestamp - this.lastClockAdvance >= REDRAW_PERIOD_MS) {
@@ -115,94 +259,46 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.rafId = requestAnimationFrame(loop);
   }
 
-  private panAndZoom(): void {
-    const container: HTMLElement = this.canvasContainer.nativeElement;
-    const W = container.clientWidth;
-    const H = container.clientHeight;
-    const fitScale = Math.min(W / CANVAS_WIDTH, H / CANVAS_HEIGHT);
+  // ── Label size ───────────────────────────────────────────────
 
-    // Transform is: scale(s) translate(x, y) with origin 50% 50%.
-    // To center canvas center (OX,OY) at viewport (W/2,H/2): x = (W/2 - OX) / s
-    const startX = (W / 2 - CANVAS_WIDTH / 2) / fitScale;
-    const startY = (H / 2 - CANVAS_HEIGHT / 2) / fitScale;
+  // Interpolates font target from 11px (at zoom ×2.5) to 13px (at zoom ×5),
+  // giving a smooth growth instead of a hard jump.
+  private static readonly LABEL_ZOOM_HIGH = 5.0;
 
-    // "Driver" instance — owns all interaction (canvas:true binds to parent)
-    const driver = Panzoom(this.canvasTrains.nativeElement, {
-      maxScale: 10, minScale: 0.05, canvas: true, step: 0.3,
-      startScale: fitScale, startX, startY,
-    });
-    // Follower instances — canvas:false so they do NOT attach their own listeners
-    const followers = [
-      Panzoom(this.canvasPaths.nativeElement,    { canvas: false, startScale: fitScale, startX, startY }),
-      Panzoom(this.canvasStations.nativeElement,  { canvas: false, startScale: fitScale, startX, startY }),
-    ];
-    this.panzoomInstances = [driver, ...followers];
-
-    this.currentScale = fitScale;
-    this.fitScale = fitScale;
-
-    // Mirror every pan/zoom from driver to followers; redraw static layers on zoom
-    const sync = (e: any) => {
-      const { x, y, scale } = e.detail;
-      followers.forEach(f => {
-        f.zoom(scale, { animate: false });
-        f.pan(x, y, { animate: false });
-      });
-    };
-    const syncAndRedraw = (e: any) => {
-      const { x, y, scale } = e.detail;
-      this.currentScale = scale;
-      followers.forEach(f => {
-        f.zoom(scale, { animate: false });
-        f.pan(x, y, { animate: false });
-      });
-      this.drawPaths(this.ctx, this.metroData.paths, scale);
-      this.drawStations(this.ctxStations, this.metroData.stations, scale);
-    };
-    this.canvasTrains.nativeElement.addEventListener('panzoompan',  sync);
-    this.canvasTrains.nativeElement.addEventListener('panzoomzoom', syncAndRedraw);
-
-    // Wheel zoom (driver handles it; sync fires automatically via events above)
-    container.addEventListener('wheel', (event: any) => {
-      driver.zoomWithWheel(event);
-    }, { passive: false });
+  private labelTargetPx(): number {
+    const mul  = this.currentScale / this.fitScale;
+    const low  = TrainComponent.LABEL_SHOW_ALL_MUL;  // 2.5
+    const high = TrainComponent.LABEL_ZOOM_HIGH;      // 5.0
+    if (mul <= low)  return TrainComponent.LABEL_SIZE_PX;
+    if (mul >= high) return TrainComponent.LABEL_SIZE_ZOOM_PX;
+    const t = (mul - low) / (high - low);
+    return TrainComponent.LABEL_SIZE_PX + t * (TrainComponent.LABEL_SIZE_ZOOM_PX - TrainComponent.LABEL_SIZE_PX);
   }
 
-  zoomIn(): void {
-    this.panzoomInstances.forEach(p => p.zoomIn());
+  // ── Drawing ──────────────────────────────────────────────────
+
+  private drawPaths(): void {
+    const ctx = this.ctxPaths;
+    this.clearCtx(ctx);
+    this.applyTransform(ctx);
+
+    ctx.lineWidth = TrainComponent.PATH_WIDTH_PX / this.currentScale;
+    ctx.lineJoin  = 'round';
+    ctx.lineCap   = 'round';
+
+    for (const segment of this.metroData.paths) {
+      if (segment.path.length < 2) continue;
+      ctx.beginPath();
+      ctx.moveTo(segment.path[0].x, segment.path[0].y);
+      for (const p of segment.path.slice(1)) ctx.lineTo(p.x, p.y);
+      ctx.strokeStyle = this.lineColors(segment.line);
+      ctx.stroke();
+    }
   }
 
-  zoomOut(): void {
-    this.panzoomInstances.forEach(p => p.zoomOut());
-  }
-
-  zoomReset(): void {
-    const container: HTMLElement = this.canvasContainer.nativeElement;
-    const W = container.clientWidth;
-    const H = container.clientHeight;
-    const fitScale = Math.min(W / CANVAS_WIDTH, H / CANVAS_HEIGHT);
-    const x = (W / 2 - CANVAS_WIDTH / 2) / fitScale;
-    const y = (H / 2 - CANVAS_HEIGHT / 2) / fitScale;
-    this.panzoomInstances.forEach(p => p.zoom(fitScale, { animate: true }));
-    this.panzoomInstances.forEach(p => p.pan(x, y, { animate: true }));
-  }
-
-  // Target visual sizes in CSS pixels (independent of zoom)
-  private static readonly DOT_RADIUS_PX   = 5;   // station dot radius on screen
-  private static readonly DOT_STROKE_PX   = 1.2;
-  private static readonly LABEL_SIZE_PX      = 11;  // font size on screen (low zoom)
-  private static readonly LABEL_SIZE_ZOOM_PX = 13;  // font size on screen (high zoom / show-all)
-  private static readonly LABEL_MIN_SCALE    = 0.35; // hide labels below this zoom
-
-  // Responsive line width: ~6px on a 1200px-wide container, scales with viewport
-  private get pathWidthPx(): number {
-    const w = (this.canvasContainer.nativeElement as HTMLElement).clientWidth;
-    return Math.max(4, Math.min(8, w / 200));
-  }
-
-  // Pre-compute which labels to show at fitScale (stable set across all zoom levels).
+  // Pre-compute which labels to show at fitScale — stable across all zoom levels
   private computeLabelVisibility(): void {
-    const scale = this.fitScale;
+    const scale   = this.fitScale;
     const fontSize = Math.round(TrainComponent.LABEL_SIZE_PX / scale);
     this.ctxStations.font = `${fontSize}px Inter, Verdana, sans-serif`;
     const r       = TrainComponent.DOT_RADIUS_PX / scale;
@@ -218,39 +314,39 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       const bx = lx - padding;
       const by = ly - fontSize * 0.85;
       const overlaps = placed.some(p =>
-        bx < p.x + p.w && bx + bw > p.x && by < p.y + p.h && by + bh > p.y
+        bx < p.x + p.w && bx + bw > p.x && by < p.y + p.h && by + bh > p.y,
       );
-      if (!overlaps) { placed.push({ x: bx, y: by, w: bw, h: bh }); }
+      if (!overlaps) placed.push({ x: bx, y: by, w: bw, h: bh });
       return !overlaps;
     });
   }
 
-  private drawStations(ctx: CanvasRenderingContext2D, stations: Station[], scale: number): void {
-    ctx.clearRect(0, 0, this.width, this.height);
+  private drawStations(): void {
+    const ctx   = this.ctxStations;
+    const scale = this.currentScale;
+    this.clearCtx(ctx);
+    this.applyTransform(ctx);
+
     const r   = TrainComponent.DOT_RADIUS_PX / scale;
     const lw  = TrainComponent.DOT_STROKE_PX / scale;
-    const showLabels = scale >= TrainComponent.LABEL_MIN_SCALE;
-    // At high zoom the viewport shows only a small area, so show all labels
-    const showAll = (scale / this.fitScale) >= TrainComponent.LABEL_SHOW_ALL_ZOOM;
-    const targetPx = showAll ? TrainComponent.LABEL_SIZE_ZOOM_PX : TrainComponent.LABEL_SIZE_PX;
-    const fontSize = Math.round(targetPx / scale);
+    const showLabels = scale >= this.fitScale * 0.8;
+    const showAll    = (scale / this.fitScale) >= TrainComponent.LABEL_SHOW_ALL_MUL;
+    const fontSize   = Math.round(this.labelTargetPx() / scale);
 
     ctx.fillStyle   = 'white';
     ctx.strokeStyle = '#0d1117';
     ctx.lineWidth   = lw;
-    if (showLabels) {
-      ctx.font = `${fontSize}px Inter, Verdana, sans-serif`;
-    }
+    if (showLabels) ctx.font = `${fontSize}px Inter, Verdana, sans-serif`;
 
-    stations.forEach((station, i) => {
+    this.metroData.stations.forEach((station, i) => {
       const { x, y } = station.position;
-      // Dot
+
       ctx.beginPath();
       ctx.arc(x, y, r, 0, Math.PI * 2);
       ctx.fill();
       ctx.stroke();
       ctx.closePath();
-      // Label: use pre-computed visibility or show all at high zoom
+
       if (showLabels && (showAll || this.labelVisible[i])) {
         const padding = 2 / scale;
         const lx = x + r + padding;
@@ -265,30 +361,21 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  private drawPaths(ctx: CanvasRenderingContext2D, stations: Station[], scale: number): void {
-    ctx.clearRect(0, 0, this.width, this.height);
-    ctx.lineWidth  = this.pathWidthPx / scale;
-    ctx.lineJoin   = 'round';
-    ctx.lineCap    = 'round';
-    for (const station of stations) {
-      if (station.path.length < 2) continue;
-      ctx.beginPath();
-      ctx.moveTo(station.path[0].x, station.path[0].y);
-      for (const p of station.path.slice(1)) {
-        ctx.lineTo(p.x, p.y);
-      }
-      ctx.strokeStyle = this.lineColors(station.line);
-      ctx.stroke();
-      ctx.closePath();
+  private drawTrains(): void {
+    const ctx   = this.ctxTrains;
+    const scale = this.currentScale;
+    this.clearCtx(ctx);
+    this.applyTransform(ctx);
+
+    ctx.fillStyle = 'red';
+    const w = 12 / scale;
+    const h =  5 / scale;
+    for (const train of this.state.trains) {
+      ctx.fillRect(train.x, train.y, w, h);
     }
   }
 
-  private drawTrains(trains: Train[]): void {
-    this.ctxTrains.clearRect(0, 0, this.width, this.height);
-    for (const train of trains) {
-      this.ctxTrains.fillRect(train.x, train.y, 15, 5);
-    }
-  }
+  // ── Clock ────────────────────────────────────────────────────
 
   private advanceClock(): void {
     this.time += REDRAW_PERIOD_MS / this.state.timeMultiplier;
@@ -296,13 +383,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   displayClock(): string {
     return new Date(this.time).toLocaleTimeString('en-GB', {
-      timeZone: 'Etc/UTC',
-      hour12: false,
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
+      timeZone: 'Etc/UTC', hour12: false,
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
     });
   }
+
+  // ── Stats helpers ────────────────────────────────────────────
 
   linePeople(): [string, number][] {
     return Array.from(this.state.platformsPeople.entries())


### PR DESCRIPTION
## Summary

- **Root cause fixed**: the previous approach applied CSS `transform: scale()` to a fixed 3400×2000 canvas, causing pixel interpolation blur at high zoom. No amount of patching (DPR, font clamping, label caching) could fully solve it.
- **Semantic zoom**: canvas is now sized to the viewport × devicePixelRatio. Pan and zoom are tracked as `(panX, panY, scale)` and applied via `ctx.setTransform()` before every draw — the canvas always renders at native resolution, zero degradation at any zoom level.
- Panzoom library removed from this component; wheel and drag events handled directly with zoom-toward-cursor behaviour.
- Label font size interpolates smoothly from 11px to 13px between ×2.5 and ×5 zoom (no hard jumps).
- Label visibility pre-computed once at fit scale — stable set across all zoom levels, no flickering between steps.
- Dev-only zoom indicator (hidden in production builds).
- Checkpoint commit `44bd6b0` on this branch preserves the previous CSS-transform approach in case of rollback.

## Test plan

- [ ] Zoom 0 (fit view): full network visible, lines and labels readable
- [ ] Zoom ×1–×2.5: lines and labels scale smoothly, no blur
- [ ] Zoom ×2.5–×5: all labels appear, font grows gradually, no jumps
- [ ] Zoom ×5+: sharp at any level, no degradation
- [ ] Pan: map follows cursor/drag correctly
- [ ] Zoom buttons and reset work
- [ ] `npm run build` (prod): zoom indicator absent