### PR TITLE
feat: Metro Simu rename, pill trains, dual panels

### DIFF
--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -1,7 +1,7 @@
 <header class="topbar">
   <div class="topbar-left">
     <span class="material-icons topbar-icon">train</span>
-    <span class="topbar-title">Metro Madrid</span>
+    <span class="topbar-title">Metro Simu</span>
   </div>
   <div class="topbar-right">
     @if (status$ | async; as s) {

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -40,7 +40,6 @@
 .panel {
   position: absolute;
   top: 12px;
-  right: 12px;
   width: 220px;
   background: rgba(13, 17, 23, 0.92);
   border: 1px solid #30363d;
@@ -50,6 +49,9 @@
   transition: width 0.2s ease;
   overflow: hidden;
 }
+
+.panel-left  { left:  12px; }
+.panel-right { right: 12px; }
 
 .panel--collapsed {
   width: 36px;
@@ -191,6 +193,32 @@
   min-width: 28px;
   text-align: right;
   flex-shrink: 0;
+}
+
+/* ── Edit config button ──────────────────────────────────── */
+.edit-btn {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 6px;
+  padding: 5px 8px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #8b949e;
+  font-size: 11px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  width: 100%;
+}
+
+.edit-btn:hover {
+  color: #e6edf3;
+  border-color: #58a6ff;
+}
+
+.edit-btn .material-icons {
+  font-size: 13px;
 }
 
 /* ── Zoom indicator (dev only) ───────────────────────────── */

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -7,14 +7,14 @@
     <canvas #canvas_trains   class="canvas-layer"></canvas>
   </div>
 
-  <!-- Stats panel (floating) -->
-  <aside class="panel" [class.panel--collapsed]="panelCollapsed">
-    <button class="panel-toggle" (click)="panelCollapsed = !panelCollapsed"
-            [title]="panelCollapsed ? 'Expand' : 'Collapse'">
-      <span class="material-icons">{{ panelCollapsed ? 'chevron_right' : 'chevron_left' }}</span>
+  <!-- Left panel: configurable parameters -->
+  <aside class="panel panel-left" [class.panel--collapsed]="leftCollapsed">
+    <button class="panel-toggle" (click)="leftCollapsed = !leftCollapsed"
+            [title]="leftCollapsed ? 'Expand' : 'Collapse'">
+      <span class="material-icons">{{ leftCollapsed ? 'chevron_right' : 'chevron_left' }}</span>
     </button>
 
-    @if (!panelCollapsed) {
+    @if (!leftCollapsed) {
       <div class="panel-body">
 
         <div class="panel-section">
@@ -24,6 +24,44 @@
         </div>
 
         <div class="panel-divider"></div>
+
+        <div class="panel-section">
+          <span class="panel-label">TRAIN CONFIG</span>
+          <div class="stat-row">
+            <span class="stat-name">Wagon cap.</span>
+            <span class="stat-val">{{ cfg.config.wagonCapacity }}</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-name">Wagons/train</span>
+            <span class="stat-val">{{ cfg.config.wagonsPerTrain }}</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-name">Trains/15 min</span>
+            <span class="stat-val">{{ cfg.config.trainsPerQuarterHour }}</span>
+          </div>
+          <div class="stat-row capacity">
+            <span class="stat-name">Capacity</span>
+            <span class="stat-val">{{ cfg.trainCapacity }} pax</span>
+          </div>
+          <button class="edit-btn" (click)="openConfig()">
+            <span class="material-icons">edit</span>
+            Edit config
+          </button>
+        </div>
+
+      </div>
+    }
+  </aside>
+
+  <!-- Right panel: simulation results -->
+  <aside class="panel panel-right" [class.panel--collapsed]="rightCollapsed">
+    <button class="panel-toggle" (click)="rightCollapsed = !rightCollapsed"
+            [title]="rightCollapsed ? 'Expand' : 'Collapse'">
+      <span class="material-icons">{{ rightCollapsed ? 'chevron_left' : 'chevron_right' }}</span>
+    </button>
+
+    @if (!rightCollapsed) {
+      <div class="panel-body">
 
         <div class="panel-section">
           <span class="panel-label">PEOPLE</span>
@@ -46,28 +84,6 @@
           <div class="stat-row">
             <span class="stat-name">Stations</span>
             <span class="stat-val">{{ allPeople(state.stationsPeople) }}</span>
-          </div>
-        </div>
-
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">TRAIN CONFIG</span>
-          <div class="stat-row">
-            <span class="stat-name">Wagon cap.</span>
-            <span class="stat-val">{{ cfg.config.wagonCapacity }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Wagons/train</span>
-            <span class="stat-val">{{ cfg.config.wagonsPerTrain }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Trains/15 min</span>
-            <span class="stat-val">{{ cfg.config.trainsPerQuarterHour }}</span>
-          </div>
-          <div class="stat-row capacity">
-            <span class="stat-name">Capacity</span>
-            <span class="stat-val">{{ cfg.trainCapacity }} pax</span>
           </div>
         </div>
 

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -3,10 +3,13 @@ import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
+import { MatDialog } from '@angular/material/dialog';
+
 import { WebSocketService } from '../services/websocket.service';
 import { MetroDataService } from '../services/metro-data.service';
 import { SimulationStateService } from '../services/simulation-state.service';
 import { SimulationConfigService } from '../services/simulation-config.service';
+import { ConfigDialogComponent } from '../config-dialog/config-dialog.component';
 import { REDRAW_PERIOD_MS, LINE_COLORS } from '../constants';
 
 @Component({
@@ -27,7 +30,8 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   private ctxPaths!: CanvasRenderingContext2D;
   private ctxTrains!: CanvasRenderingContext2D;
 
-  panelCollapsed = false;
+  leftCollapsed  = false;
+  rightCollapsed = false;
 
   // Zoom state — exposed to template for the dev indicator
   currentScale = 1;
@@ -61,6 +65,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     private readonly wsService: WebSocketService,
+    private readonly dialog: MatDialog,
     readonly metroData: MetroDataService,
     readonly state: SimulationStateService,
     readonly cfg: SimulationConfigService,
@@ -367,12 +372,37 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
-    ctx.fillStyle = 'red';
-    const w = 12 / scale;
-    const h =  5 / scale;
+    const w  = 18 / scale;   // train length  (screen px / scale = world units)
+    const h  =  7 / scale;   // train height
+    const r  =  h / 2;       // full half-height → pill shape
+    const lw =  1 / scale;
+
+    ctx.fillStyle   = '#e6edf3';
+    ctx.strokeStyle = 'rgba(0,0,0,0.55)';
+    ctx.lineWidth   = lw;
+
     for (const train of this.state.trains) {
-      ctx.fillRect(train.x, train.y, w, h);
+      const x = train.x - w / 2;
+      const y = train.y - h / 2;
+      this.pillRect(ctx, x, y, w, h, r);
+      ctx.fill();
+      ctx.stroke();
     }
+  }
+
+  // Cross-browser rounded rectangle (pill when r = h/2)
+  private pillRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.lineTo(x + w - r, y);
+    ctx.arcTo(x + w, y,     x + w, y + r,     r);
+    ctx.lineTo(x + w, y + h - r);
+    ctx.arcTo(x + w, y + h, x + w - r, y + h, r);
+    ctx.lineTo(x + r, y + h);
+    ctx.arcTo(x,     y + h, x,     y + h - r, r);
+    ctx.lineTo(x,     y + r);
+    ctx.arcTo(x,     y,     x + r, y,         r);
+    ctx.closePath();
   }
 
   // ── Clock ────────────────────────────────────────────────────
@@ -386,6 +416,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       timeZone: 'Etc/UTC', hour12: false,
       hour: '2-digit', minute: '2-digit', second: '2-digit',
     });
+  }
+
+  openConfig(): void {
+    this.dialog.open(ConfigDialogComponent, { width: '420px' });
   }
 
   // ── Stats helpers ────────────────────────────────────────────

--- a/metro/src/index.html
+++ b/metro/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Metro Madrid</title>
+  <title>Metro Simu</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">


### PR DESCRIPTION
## Summary

- **Rename**: "Metro Madrid" → "Metro Simu" (title tag + header) so the app is city-agnostic
- **Train rendering**: replaced plain red rectangles with white pill-shaped capsules centered on track coordinates (cross-browser `arcTo`-based rounded rect, 18×7px screen size)
- **Dual panels**:
  - **Left** — configurable parameters: clock, time speed, wagon capacity, wagons/train, trains per 15 min, train capacity, with an *Edit config* button that opens the existing config dialog
  - **Right** — simulation results: people counts (simulation / metro / trains / platforms / stations) and by-line breakdown with bars

## Test plan

- [ ] Title shows "Metro Simu" in browser tab and header
- [ ] Trains appear as white capsules on the map, visible at all zoom levels
- [ ] Left panel shows config values; Edit button opens the config dialog correctly
- [ ] Right panel shows live people counts updated via WebSocket
- [ ] Both panels collapse/expand with their toggle buttons