### PR TITLE
feat: smooth train movement between platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .idea
 */.idea/*
+
+# Claude Code internal files
+plan
+resume
+skills-lock.json
+.agents/

--- a/metro/src/app/services/simulation-state.service.spec.ts
+++ b/metro/src/app/services/simulation-state.service.spec.ts
@@ -35,12 +35,12 @@ describe('SimulationStateService', () => {
     expect(service.dirty).toBeTrue();
   });
 
-  it('process moveTrain should update position and set dirty', () => {
+  it('process moveTrain should update target position and set dirty', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.dirty = false;
     service.process({ message: 'moveTrain', train: 'T1', x: 50, y: 75 });
-    expect(service.trains[0].x).toBe(50);
-    expect(service.trains[0].y).toBe(75);
+    expect(service.trains[0].targetX).toBe(50);
+    expect(service.trains[0].targetY).toBe(75);
     expect(service.dirty).toBeTrue();
   });
 

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -31,8 +31,12 @@ export class SimulationStateService {
       case 'moveTrain': {
         const train = this.trainsMap.get(msg.train);
         if (train) {
-          train.x = msg.x;
-          train.y = msg.y;
+          train.fromX = train.x;
+          train.fromY = train.y;
+          train.targetX = msg.x;
+          train.targetY = msg.y;
+          train.departedAt = performance.now();
+          train.travelMs = 135_000 / this.timeMultiplier;
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
           this.dirty = true;
@@ -42,8 +46,12 @@ export class SimulationStateService {
       case 'newTrain': {
         const existing = this.trainsMap.get(msg.train);
         if (existing) {
-          existing.x = msg.x;
-          existing.y = msg.y;
+          existing.fromX = existing.x;
+          existing.fromY = existing.y;
+          existing.targetX = msg.x;
+          existing.targetY = msg.y;
+          existing.departedAt = performance.now();
+          existing.travelMs = 135_000 / this.timeMultiplier;
           if (msg.people   !== undefined) existing.people   = msg.people;
           if (msg.capacity !== undefined) existing.capacity = msg.capacity;
         } else {

--- a/metro/src/app/train.ts
+++ b/metro/src/app/train.ts
@@ -3,6 +3,12 @@ export class Train {
   id: string;
   x: number;
   y: number;
+  fromX: number;
+  fromY: number;
+  targetX: number;
+  targetY: number;
+  departedAt: number;
+  travelMs: number;
   people: number;
   capacity: number;
 
@@ -10,6 +16,12 @@ export class Train {
     this.id = id;
     this.x = x;
     this.y = y;
+    this.fromX = x;
+    this.fromY = y;
+    this.targetX = x;
+    this.targetY = y;
+    this.departedAt = 0;
+    this.travelMs = 0;
     this.people = people;
     this.capacity = capacity;
   }

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -259,11 +259,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         this.needsStaticRedraw = false;
       }
 
-      if (this.state.dirty || this.needsTrainRedraw) {
-        this.drawTrains();
-        this.state.dirty      = false;
-        this.needsTrainRedraw = false;
-      }
+      this.drawTrains(timestamp);
+      this.state.dirty      = false;
+      this.needsTrainRedraw = false;
 
       // Trigger Angular CD at ~5 fps so the template (clock, people) stays current
       if (timestamp - this.lastCdTick >= 200) {
@@ -378,7 +376,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  private drawTrains(): void {
+  private drawTrains(now: number): void {
     const ctx   = this.ctxTrains;
     const scale = this.currentScale;
     this.clearCtx(ctx);
@@ -392,6 +390,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     ctx.lineWidth = lw;
 
     for (const train of this.state.trains) {
+      // Interpolate position between last known position and target
+      if (train.travelMs > 0) {
+        const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
+        const ease = t * t * (3 - 2 * t); // smoothstep
+        train.x = train.fromX + (train.targetX - train.fromX) * ease;
+        train.y = train.fromY + (train.targetY - train.fromY) * ease;
+      }
+
       const x   = train.x - w / 2;
       const y   = train.y - h / 2;
       const occ = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;


### PR DESCRIPTION
## Summary

- Each `moveTrain` / `newTrain` message snapshots the current draw position as `fromX/Y` and sets `targetX/Y`
- Travel duration is estimated as `135 000 ms / timeMultiplier` (midpoint of the [90–180 s] inter-platform interval, scaled to real time)
- The RAF loop interpolates with **smoothstep** `t² (3 − 2t)` every frame — trains ease in and out smoothly
- If a new `moveTrain` arrives mid-journey, the animation restarts from the current interpolated position, so there are no snapping artefacts
- `drawTrains` now runs every frame (trains are always moving), removing the now-unnecessary `dirty` guard
- Claude Code internal files (`plan`, `resume`, `skills-lock.json`, `.agents/`) added to `.gitignore`

## Changes

| File | Change |
|------|--------|
| `train.ts` | Added `fromX/Y`, `targetX/Y`, `departedAt`, `travelMs` fields |
| `simulation-state.service.ts` | `moveTrain`/`newTrain` set animation origin + target instead of jumping |
| `train.component.ts` | `drawTrains(now)` interpolates position per frame using smoothstep |
| `.gitignore` | Ignore Claude Code internal files |

Closes #54