### PR TITLE
feat: inline config, reset button, fix line bar alignment

### DIFF
--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -26,6 +26,16 @@ export class SimulationStateService {
     }
   }
 
+  reset(): void {
+    this.trainsMap.clear();
+    this.simulationPeople = 0;
+    this.metroPeople = 0;
+    this.trainsPeople = 0;
+    for (const key of this.platformsPeople.keys()) this.platformsPeople.set(key, 0);
+    for (const key of this.stationsPeople.keys()) this.stationsPeople.set(key, 0);
+    this.dirty = true;
+  }
+
   process(msg: SimulationMessage): void {
     switch (msg.message) {
       case 'moveTrain': {

--- a/metro/src/app/services/websocket.service.ts
+++ b/metro/src/app/services/websocket.service.ts
@@ -14,8 +14,10 @@ export class WebSocketService {
   readonly connectionStatus$ = new BehaviorSubject<ConnectionStatus>('disconnected');
   readonly messages$: Observable<SimulationMessage>;
 
+  private readonly socket$;
+
   constructor() {
-    const socket$ = webSocket<SimulationMessage>({
+    this.socket$ = webSocket<SimulationMessage>({
       url: environment.wsUrl,
       openObserver: {
         next: () => this.connectionStatus$.next('connected'),
@@ -25,7 +27,7 @@ export class WebSocketService {
       },
     });
 
-    this.messages$ = socket$.pipe(
+    this.messages$ = this.socket$.pipe(
       retry({
         delay: (_error, _count) => {
           this.connectionStatus$.next('reconnecting');
@@ -33,5 +35,9 @@ export class WebSocketService {
         },
       }),
     );
+  }
+
+  send(msg: object): void {
+    this.socket$.next(msg as SimulationMessage);
   }
 }

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -167,7 +167,7 @@
   font-size: 10px;
   font-weight: 600;
   color: #e6edf3;
-  width: 16px;
+  width: 26px;
   text-align: right;
   flex-shrink: 0;
 }
@@ -190,17 +190,56 @@
 .line-count {
   font-size: 10px;
   color: #8b949e;
-  min-width: 28px;
+  min-width: 34px;
   text-align: right;
   flex-shrink: 0;
 }
 
-/* ── Edit config button ──────────────────────────────────── */
-.edit-btn {
+/* ── Inline config inputs ────────────────────────────────── */
+.cfg-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 2px 0;
+  gap: 6px;
+}
+
+.cfg-label {
+  font-size: 11px;
+  color: #8b949e;
+  flex: 1;
+}
+
+.cfg-input {
+  width: 52px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #e6edf3;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 5px;
+  text-align: right;
+  appearance: textfield;
+  -moz-appearance: textfield;
+  flex-shrink: 0;
+}
+
+.cfg-input::-webkit-inner-spin-button,
+.cfg-input::-webkit-outer-spin-button {
+  opacity: 0.4;
+}
+
+.cfg-input:focus {
+  outline: none;
+  border-color: #58a6ff;
+}
+
+/* ── Reset button ────────────────────────────────────────── */
+.reset-btn {
   display: flex;
   align-items: center;
   gap: 5px;
-  margin-top: 6px;
   padding: 5px 8px;
   background: #161b22;
   border: 1px solid #30363d;
@@ -212,12 +251,12 @@
   width: 100%;
 }
 
-.edit-btn:hover {
-  color: #e6edf3;
-  border-color: #58a6ff;
+.reset-btn:hover {
+  color: #f85149;
+  border-color: #f85149;
 }
 
-.edit-btn .material-icons {
+.reset-btn .material-icons {
   font-size: 13px;
 }
 

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -190,12 +190,15 @@
 .line-count {
   font-size: 10px;
   color: #8b949e;
-  min-width: 34px;
+  width: 34px;
   text-align: right;
   flex-shrink: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-/* ── Inline config inputs ────────────────────────────────── */
+/* ── Inline config rows ──────────────────────────────────── */
 .cfg-row {
   display: flex;
   justify-content: space-between;
@@ -208,29 +211,74 @@
   font-size: 11px;
   color: #8b949e;
   flex: 1;
+  white-space: nowrap;
 }
 
-.cfg-input {
-  width: 52px;
+/* ── Stepper control ─────────────────────────────────────── */
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.stepper-btn {
+  width: 24px;
+  height: 24px;
+  background: #161b22;
+  border: none;
+  color: #8b949e;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  transition: color 0.12s, background 0.12s;
+  flex-shrink: 0;
+}
+
+.stepper-btn:hover {
+  color: #e6edf3;
+  background: #21262d;
+}
+
+.stepper-val {
+  min-width: 36px;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: #e6edf3;
+  background: #0d1117;
+  padding: 0 4px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-left: 1px solid #30363d;
+  border-right: 1px solid #30363d;
+}
+
+/* ── Time input ──────────────────────────────────────────── */
+.time-input {
   background: #161b22;
   border: 1px solid #30363d;
   border-radius: 4px;
   color: #e6edf3;
   font-size: 11px;
   font-weight: 600;
-  padding: 2px 5px;
-  text-align: right;
-  appearance: textfield;
-  -moz-appearance: textfield;
+  padding: 3px 5px;
+  width: 80px;
+  text-align: center;
   flex-shrink: 0;
+  color-scheme: dark;
 }
 
-.cfg-input::-webkit-inner-spin-button,
-.cfg-input::-webkit-outer-spin-button {
-  opacity: 0.4;
-}
-
-.cfg-input:focus {
+.time-input:focus {
   outline: none;
   border-color: #58a6ff;
 }
@@ -240,6 +288,7 @@
   display: flex;
   align-items: center;
   gap: 5px;
+  margin-top: 4px;
   padding: 5px 8px;
   background: #161b22;
   border: 1px solid #30363d;

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -27,25 +27,37 @@
 
         <div class="panel-section">
           <span class="panel-label">TRAIN CONFIG</span>
-          <div class="stat-row">
-            <span class="stat-name">Wagon cap.</span>
-            <span class="stat-val">{{ cfg.config.wagonCapacity }}</span>
+          <div class="cfg-row">
+            <label class="cfg-label">Wagon cap.</label>
+            <input class="cfg-input" type="number" min="1" max="500"
+                   [value]="cfg.config.wagonCapacity"
+                   (change)="updateConfig('wagonCapacity', $event)">
           </div>
-          <div class="stat-row">
-            <span class="stat-name">Wagons/train</span>
-            <span class="stat-val">{{ cfg.config.wagonsPerTrain }}</span>
+          <div class="cfg-row">
+            <label class="cfg-label">Wagons/train</label>
+            <input class="cfg-input" type="number" min="1" max="20"
+                   [value]="cfg.config.wagonsPerTrain"
+                   (change)="updateConfig('wagonsPerTrain', $event)">
           </div>
-          <div class="stat-row">
-            <span class="stat-name">Trains/15 min</span>
-            <span class="stat-val">{{ cfg.config.trainsPerQuarterHour }}</span>
+          <div class="cfg-row">
+            <label class="cfg-label">Trains/15 min</label>
+            <input class="cfg-input" type="number" min="1" max="30"
+                   [value]="cfg.config.trainsPerQuarterHour"
+                   (change)="updateConfig('trainsPerQuarterHour', $event)">
           </div>
           <div class="stat-row capacity">
             <span class="stat-name">Capacity</span>
             <span class="stat-val">{{ cfg.trainCapacity }} pax</span>
           </div>
-          <button class="edit-btn" (click)="openConfig()">
-            <span class="material-icons">edit</span>
-            Edit config
+        </div>
+
+        <div class="panel-divider"></div>
+
+        <div class="panel-section">
+          <span class="panel-label">SIMULATION</span>
+          <button class="reset-btn" (click)="resetSimulation()">
+            <span class="material-icons">restart_alt</span>
+            Reset to 06:05
           </button>
         </div>
 

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -29,21 +29,19 @@
           <span class="panel-label">TRAIN CONFIG</span>
           <div class="cfg-row">
             <label class="cfg-label">Wagon cap.</label>
-            <input class="cfg-input" type="number" min="1" max="500"
-                   [value]="cfg.config.wagonCapacity"
-                   (change)="updateConfig('wagonCapacity', $event)">
+            <div class="stepper">
+              <button class="stepper-btn" (click)="stepConfig('wagonCapacity', -5)">−</button>
+              <span class="stepper-val">{{ cfg.config.wagonCapacity }}</span>
+              <button class="stepper-btn" (click)="stepConfig('wagonCapacity', 5)">+</button>
+            </div>
           </div>
           <div class="cfg-row">
             <label class="cfg-label">Wagons/train</label>
-            <input class="cfg-input" type="number" min="1" max="20"
-                   [value]="cfg.config.wagonsPerTrain"
-                   (change)="updateConfig('wagonsPerTrain', $event)">
-          </div>
-          <div class="cfg-row">
-            <label class="cfg-label">Trains/15 min</label>
-            <input class="cfg-input" type="number" min="1" max="30"
-                   [value]="cfg.config.trainsPerQuarterHour"
-                   (change)="updateConfig('trainsPerQuarterHour', $event)">
+            <div class="stepper">
+              <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', -1)">−</button>
+              <span class="stepper-val">{{ cfg.config.wagonsPerTrain }}</span>
+              <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', 1)">+</button>
+            </div>
           </div>
           <div class="stat-row capacity">
             <span class="stat-name">Capacity</span>
@@ -54,10 +52,30 @@
         <div class="panel-divider"></div>
 
         <div class="panel-section">
+          <span class="panel-label">SPEED</span>
+          <div class="cfg-row">
+            <label class="cfg-label">Sim speed</label>
+            <div class="stepper">
+              <button class="stepper-btn" (click)="speedDown()">−</button>
+              <span class="stepper-val">×{{ localSpeed }}</span>
+              <button class="stepper-btn" (click)="speedUp()">+</button>
+            </div>
+          </div>
+        </div>
+
+        <div class="panel-divider"></div>
+
+        <div class="panel-section">
           <span class="panel-label">SIMULATION</span>
+          <div class="cfg-row">
+            <label class="cfg-label">Start time</label>
+            <input class="time-input" type="time"
+                   [value]="resetTime"
+                   (change)="resetTime = $any($event.target).value">
+          </div>
           <button class="reset-btn" (click)="resetSimulation()">
             <span class="material-icons">restart_alt</span>
-            Reset to 06:05
+            Reset
           </button>
         </div>
 
@@ -113,7 +131,7 @@
                      [style.background]="lineColors(line[0])">
                 </div>
               </div>
-              <span class="line-count">{{ line[1] }}</span>
+              <span class="line-count">{{ formatCount(line[1]) }}</span>
             </div>
           }
         </div>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -3,13 +3,10 @@ import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
-import { MatDialog } from '@angular/material/dialog';
-
 import { WebSocketService } from '../services/websocket.service';
 import { MetroDataService } from '../services/metro-data.service';
 import { SimulationStateService } from '../services/simulation-state.service';
 import { SimulationConfigService } from '../services/simulation-config.service';
-import { ConfigDialogComponent } from '../config-dialog/config-dialog.component';
 import { LINE_COLORS } from '../constants';
 
 @Component({
@@ -66,7 +63,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     private readonly wsService: WebSocketService,
-    private readonly dialog: MatDialog,
     private readonly ngZone: NgZone,
     private readonly cd: ChangeDetectorRef,
     readonly metroData: MetroDataService,
@@ -447,8 +443,18 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  openConfig(): void {
-    this.dialog.open(ConfigDialogComponent, { width: '420px' });
+  updateConfig(field: string, event: Event): void {
+    const value = parseInt((event.target as HTMLInputElement).value, 10);
+    if (!isNaN(value)) {
+      this.cfg.save({ ...this.cfg.config, [field]: value });
+    }
+  }
+
+  resetSimulation(): void {
+    this.time = 6 * 3600 * 1000;
+    this.state.reset();
+    this.wsService.send({ message: 'reset' });
+    this.cd.detectChanges();
   }
 
   // ── Stats helpers ────────────────────────────────────────────

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -50,6 +50,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private destroyed = false;
 
+  // Speed presets: local multiplier on top of backend timeMultiplier
+  private static readonly SPEED_PRESETS = [0.25, 0.5, 1, 2, 5, 10, 20];
+  private speedIdx = 2; // default ×1
+  get localSpeed(): number { return TrainComponent.SPEED_PRESETS[this.speedIdx]; }
+
+  // Reset clock target
+  resetTime = '06:05';
+
   // Label visibility pre-computed at fitScale — stable set across all zoom levels
   private labelVisible: boolean[] = [];
 
@@ -247,7 +255,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       // Advance simulation clock every frame (smooth)
       const dt = this.lastRafTimestamp > 0 ? timestamp - this.lastRafTimestamp : 0;
       this.lastRafTimestamp = timestamp;
-      this.time += dt / this.state.timeMultiplier;
+      this.time += dt * this.localSpeed / this.state.timeMultiplier;
 
       if (this.needsStaticRedraw) {
         this.drawPaths();
@@ -443,18 +451,26 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
-  updateConfig(field: string, event: Event): void {
-    const value = parseInt((event.target as HTMLInputElement).value, 10);
-    if (!isNaN(value)) {
-      this.cfg.save({ ...this.cfg.config, [field]: value });
-    }
+  stepConfig(field: keyof typeof this.cfg.config, delta: number): void {
+    const next = this.cfg.config[field] + delta;
+    this.cfg.save({ ...this.cfg.config, [field]: next });
   }
 
+  speedDown(): void { this.speedIdx = Math.max(0, this.speedIdx - 1); }
+  speedUp():   void { this.speedIdx = Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1); }
+
   resetSimulation(): void {
-    this.time = 6 * 3600 * 1000;
+    const [h, m] = this.resetTime.split(':').map(Number);
+    this.time = ((h || 6) * 3600 + (m || 0)) * 1000;
     this.state.reset();
     this.wsService.send({ message: 'reset' });
     this.cd.detectChanges();
+  }
+
+  formatCount(n: number): string {
+    if (n >= 10_000) return `${Math.round(n / 1000)}k`;
+    if (n >= 1_000)  return `${(n / 1000).toFixed(1)}k`;
+    return String(n);
   }
 
   // ── Stats helpers ────────────────────────────────────────────


### PR DESCRIPTION
## Changes

### Left panel — inline config (removes modal)
- Replaced the "Edit config" button + `MatDialog` popup with inline `<input type="number">` fields directly in the panel
- Values update immediately on change (`(change)` event → `cfg.save()`)
- Removed `MatDialog`, `ConfigDialogComponent` import from `TrainComponent`

### Left panel — Reset button
- New "Reset to 06:05" button resets the frontend clock, clears all simulation state, and sends `{ "message": "reset" }` to the backend
- Backend reset handler is tracked in #60
- Button turns red on hover to signal destructive action

### Right panel — line bar alignment fix
- `line-num` width: `16px` → `26px` — fits all line names including "ML1", "ML2", "ML3", "L1"–"L3" (from `msg.line.slice(1)`)
- `line-count` min-width: `28px` → `34px` — avoids overflow on larger numbers

### SimulationStateService
- Added `reset()` method: clears trains map, zeros all people counters

### WebSocketService
- Exposed `send(msg)` method to allow the component to send commands upstream

Related: #60