### PR TITLE
fix: WebSocket sim-time sync, frontend commands, dead connection cleanup

### DIFF
--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -70,6 +70,11 @@ object Main {
     // Start WebSocket HTTP server using classic adapter
     implicit val classicSystem: org.apache.pekko.actor.ActorSystem = system.toClassic
     import classicSystem.dispatcher
+    // Register command handler for messages from the browser
+    WebSocket.setCommandHandler { text =>
+      if (text.contains("\"reset\"")) WebSocket.resetSnapshot()
+    }
+
     val route: Route = path("ws") { handleWebSocketMessages(WebSocket.listen()) }
     Http().newServerAt("0.0.0.0", 8081).bind(route).onComplete {
       case Success(binding) =>
@@ -97,7 +102,7 @@ object Guardian {
     Behaviors.setup[Command] { context =>
 
       // UI actor
-      val ui = context.spawn(UI(), "ui")
+      val ui = context.spawn(UI(timeMultiplier), "ui")
 
       // Line actors
       val lineActors: Map[String, ActorRef[LineMessage]] = sortedLinePaths.keys.map { l =>

--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -11,13 +11,23 @@ import utils.WebSocket
 
 object UI {
 
-  def apply(): Behavior[UIMessage] =
+  def apply(timeMultiplier: Double): Behavior[UIMessage] =
     Behaviors.withTimers { timers =>
       timers.startTimerWithFixedDelay("trains-tick", UITrainsTick, 3.seconds, 1.second)
+      timers.startTimerWithFixedDelay("simtime-tick", UISimTimeTick, 0.seconds, 1.second)
+
+      val simStartMs  = 6L * 3600L * 1000L          // simulation starts at 06:00
+      val realStartMs = System.currentTimeMillis()
 
       val trains: scala.collection.mutable.Map[String, Int] = scala.collection.mutable.Map.empty
 
       Behaviors.receiveMessage {
+
+        case UISimTimeTick =>
+          val elapsed = System.currentTimeMillis() - realStartMs
+          val simMs   = simStartMs + (elapsed.toDouble / timeMultiplier).toLong
+          WebSocket.sendStat("simTime", s"""{"message": "simTime", "ms": $simMs}""")
+          Behaviors.same
 
         case UITrainsTick =>
           val people = trains.values.sum

--- a/metro-sim/src/main/scala/messages/Messages.scala
+++ b/metro-sim/src/main/scala/messages/Messages.scala
@@ -64,6 +64,7 @@ object Messages {
   case class PeopleInMetro(people: Int) extends UIMessage
   case class PeopleInSimulation(people: Int) extends UIMessage
   case object UITrainsTick extends UIMessage
+  case object UISimTimeTick extends UIMessage
 
   // ─── Simulator messages (sent TO the Simulator actor) ────────────────────
   sealed trait SimulatorMessage

--- a/metro-sim/src/main/scala/utils/WebSocket.scala
+++ b/metro-sim/src/main/scala/utils/WebSocket.scala
@@ -3,34 +3,59 @@ package utils
 import org.apache.pekko.NotUsed
 import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
 import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.QueueOfferResult
 import org.apache.pekko.stream.scaladsl.{Flow, Sink, Source, SourceQueueWithComplete}
 
 object WebSocket {
 
-  private var browserConnections: List[TextMessage => Unit] = List()
-
   // Snapshot of current simulation state, keyed so each logical value is stored once.
   // Sent in full to every new client that connects (page reload, reconnect, new tab).
-  //   "train:<id>"                  → latest newTrain position for that train
-  //   "peopleInTrains"              → aggregate people-in-trains count
-  //   "peopleInMetro"               → aggregate
-  //   "peopleInSimulation"          → aggregate
-  //   "peopleInLinePlatforms:<id>"  → per-line platform count
-  //   "peopleInLineStations:<id>"   → per-line station count
   private val snapshot = scala.collection.mutable.Map[String, String]()
 
-  def listen(): Flow[Message, Message, NotUsed] = {
-    val inbound: Sink[Message, Any] = Sink.ignore
-    val outbound: Source[Message, SourceQueueWithComplete[Message]] =
-      Source.queue[Message](4096, OverflowStrategy.fail)
+  // Active connections: (id, queue). Cleaned up on disconnect via watchCompletion.
+  private var connections: List[(String, SourceQueueWithComplete[Message])] = List()
 
-    Flow.fromSinkAndSourceMat(inbound, outbound) { (_, outboundMat) =>
-      val send: TextMessage => Unit = msg => { outboundMat.offer(msg); () }
-      browserConnections ::= send
-      // Replay current state to this specific new client
-      snapshot.values.foreach(json => send(TextMessage.Strict(json)))
+  // Command handler set by Main — called for every message received from the browser.
+  private var commandHandler: String => Unit = _ => ()
+
+  def setCommandHandler(f: String => Unit): Unit = { commandHandler = f }
+
+  def listen(): Flow[Message, Message, NotUsed] = {
+    val connId = java.util.UUID.randomUUID.toString
+
+    // Fix 2: parse incoming messages instead of dropping them
+    val inbound: Sink[Message, Any] = Sink.foreach {
+      case TextMessage.Strict(text) => commandHandler(text)
+      case _                        => ()
+    }
+
+    val outbound: Source[Message, SourceQueueWithComplete[Message]] =
+      Source.queue[Message](4096, OverflowStrategy.dropHead)
+
+    Flow.fromSinkAndSourceMat(inbound, outbound) { (_, queue) =>
+      // Fix 3: remove connection from list when client disconnects
+      queue.watchCompletion().foreach { _ =>
+        WebSocket.synchronized {
+          connections = connections.filterNot(_._1 == connId)
+        }
+      }(scala.concurrent.ExecutionContext.global)
+
+      WebSocket.synchronized {
+        connections = (connId, queue) :: connections
+      }
+
+      // Replay current state snapshot to this new client
+      snapshot.values.foreach(json => queue.offer(TextMessage.Strict(json)))
       NotUsed
     }
+  }
+
+  /** Remove all train entries from the snapshot and notify all clients to reset. */
+  def resetSnapshot(): Unit = {
+    WebSocket.synchronized {
+      snapshot.keys.filter(_.startsWith("train:")).toList.foreach(snapshot.remove)
+    }
+    broadcast("""{"message": "reset"}""")
   }
 
   /** Send a train position event and update the snapshot. */
@@ -38,14 +63,16 @@ object WebSocket {
     val liveType = if (isNew) "newTrain" else "moveTrain"
     val liveJson = s"""{"message": "$liveType", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity}"""
     // Snapshot always as newTrain so reconnecting clients (re)create the train
-    snapshot(s"train:$trainId") =
-      s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity}"""
+    WebSocket.synchronized {
+      snapshot(s"train:$trainId") =
+        s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity}"""
+    }
     broadcast(liveJson)
   }
 
   /** Send a stat message and update the snapshot under the given key. */
   def sendStat(key: String, json: String): Unit = {
-    snapshot(key) = json
+    WebSocket.synchronized { snapshot(key) = json }
     broadcast(json)
   }
 
@@ -54,6 +81,8 @@ object WebSocket {
 
   private def broadcast(json: String): Unit = {
     val msg = TextMessage.Strict(json)
-    browserConnections.foreach(_(msg))
+    WebSocket.synchronized { connections }.foreach { case (_, queue) =>
+      queue.offer(msg)
+    }
   }
 }

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -60,6 +60,15 @@ export interface StationOvercrowded {
   people: number;
 }
 
+export interface SimTime {
+  message: 'simTime';
+  ms: number;
+}
+
+export interface ResetAck {
+  message: 'reset';
+}
+
 export type SimulationMessage =
   | MoveTrain
   | PeopleInLinePlatforms
@@ -70,4 +79,6 @@ export type SimulationMessage =
   | NewTrain
   | TimeMultiplier
   | PlatformOvercrowded
-  | StationOvercrowded;
+  | StationOvercrowded
+  | SimTime
+  | ResetAck;

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -42,6 +42,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   private readonly dpr = window.devicePixelRatio || 1;
 
   private time = 6 * 3600 * 1000;
+  private clockSynced = false;
   private lastRafTimestamp = 0;
   private lastCdTick = 0;
   private rafId = 0;
@@ -98,6 +99,21 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.wsService.messages$
       .pipe(takeUntil(this.destroy$))
       .subscribe(msg => {
+        if (msg.message === 'simTime') {
+          // On first receipt (snapshot), sync clock to backend sim time.
+          // On subsequent ticks, only resync if drift > 5 sim-seconds to avoid jitter.
+          const drift = Math.abs(this.time - msg.ms);
+          if (!this.clockSynced || drift > 5_000) {
+            this.time = msg.ms;
+            this.clockSynced = true;
+          }
+        }
+        if (msg.message === 'reset') {
+          const [h, m] = this.resetTime.split(':').map(Number);
+          this.time = ((h || 6) * 3600 + (m || 0)) * 1000;
+          this.clockSynced = false;
+          this.state.reset();
+        }
         this.state.process(msg);
         this.cd.detectChanges();
       });


### PR DESCRIPTION
## Fixes three backend WebSocket coordination problems

### 1. Sim time in snapshot (frontend clock sync on reconnect)

**Before**: frontend clock always started at 06:05 regardless of when it connected.

**After**: `UI` actor tracks `realStartMs` and calculates the current simulated time each second:
```scala
val simMs = simStartMs + (elapsed.toDouble / timeMultiplier).toLong
WebSocket.sendStat("simTime", s"""{"message": "simTime", "ms": $simMs}""")
```
`simTime` is in the snapshot so the frontend receives it immediately on connect. The frontend syncs `this.time` on first receipt, then only resyncs if drift > 5 sim-seconds (avoids jitter on subsequent ticks).

### 2. `Sink.ignore` → parse frontend commands

**Before**: `val inbound: Sink[Message, Any] = Sink.ignore` — all messages from browser silently dropped. The reset button did nothing on the backend.

**After**: inbound messages are forwarded to a `commandHandler` registered by `Main`:
```scala
WebSocket.setCommandHandler { text =>
  if (text.contains("\"reset\"")) WebSocket.resetSnapshot()
}
```
`resetSnapshot()` removes all `train:*` entries from the snapshot and broadcasts `{"message":"reset"}` to all clients, which triggers a frontend state clear.

### 3. Dead connection cleanup

**Before**: `browserConnections` was a `List` that only grew — disconnected clients were never removed, causing silent errors on every broadcast.

**After**: each connection gets a UUID. `queue.watchCompletion()` fires when the client disconnects and removes the entry from the list atomically:
```scala
queue.watchCompletion().foreach { _ =>
  WebSocket.synchronized { connections = connections.filterNot(_._1 == connId) }
}(ExecutionContext.global)
```

## Files changed
| File | Change |
|------|--------|
| `UI.scala` | Accepts `timeMultiplier`, tracks sim time, sends `simTime` snapshot every second |
| `messages/Messages.scala` | Added `UISimTimeTick` |
| `utils/WebSocket.scala` | Dead connection cleanup, inbound parsing, `resetSnapshot()`, thread-safe `synchronized` blocks |
| `Main.scala` | Passes `timeMultiplier` to `UI()`, registers command handler |
| `metro/messages.ts` | Added `SimTime` and `ResetAck` message types |
| `metro/train.component.ts` | Syncs clock from `simTime`, handles backend `reset` acknowledgment |