### PR TITLE
feat: discrete event simulation with SimClock

### DIFF
--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -31,8 +31,10 @@ object Main {
       .clearModifiers()
       .withHandler(minimumLevel = Some(Level.Info))
       .replace()
-    val timeMultiplier: Double = 1.0 / metroConf.timeMultiplier
-    scribe.info(s"Metro starting. Time multiplier: $timeMultiplier")
+    val speedFactor: Double = metroConf.timeMultiplier.toDouble
+    scribe.info(s"Metro starting. Sim speed: ${speedFactor}× real time")
+    SimClock.setSpeed(speedFactor)
+    SimClock.start()
 
     // Get daily entrance data
     val entrance: String = scala.io.Source.fromFile("data/entrance.json").mkString
@@ -63,7 +65,7 @@ object Main {
 
     // Launch typed ActorSystem with a Guardian behavior
     val system: ActorSystem[Guardian.Command] = ActorSystem(
-      Guardian(metroConf, metroGraph, sortedLinePaths, paths, stationIdsEntrance, timeMultiplier),
+      Guardian(metroConf, metroGraph, sortedLinePaths, paths, stationIdsEntrance),
       "metro-system"
     )
 
@@ -72,7 +74,17 @@ object Main {
     import classicSystem.dispatcher
     // Register command handler for messages from the browser
     WebSocket.setCommandHandler { text =>
-      if (text.contains("\"reset\"")) WebSocket.resetSnapshot()
+      if (text.contains("\"reset\"")) {
+        SimClock.reset()
+        WebSocket.resetSnapshot()
+      } else if (text.contains("\"setSpeed\"")) {
+        val factor = text.split("\"factor\"\\s*:\\s*").drop(1).headOption
+          .flatMap(_.trim.takeWhile(c => c.isDigit || c == '.').toDoubleOption)
+          .getOrElse(SimClock.speedFactor)
+        SimClock.setSpeed(factor)
+        val tm = 1.0 / SimClock.speedFactor
+        WebSocket.sendStat("timeMultiplier", s"""{"message": "timeMultiplier", "multiplier": $tm}""")
+      }
     }
 
     val route: Route = path("ws") { handleWebSocketMessages(WebSocket.listen()) }
@@ -80,7 +92,8 @@ object Main {
       case Success(binding) =>
         println(s"Listening at ${binding.localAddress.getHostString}:${binding.localAddress.getPort}")
         Thread.sleep(4000)
-        WebSocket.sendStat("timeMultiplier", s"""{"message": "timeMultiplier", "multiplier": $timeMultiplier}""")
+        val tm = 1.0 / SimClock.speedFactor
+        WebSocket.sendStat("timeMultiplier", s"""{"message": "timeMultiplier", "multiplier": $tm}""")
       case Failure(ex) => throw ex
     }
   }
@@ -96,13 +109,12 @@ object Guardian {
     metroGraph: Graph[MetroNode, WDiEdge],
     sortedLinePaths: Map[String, Seq[Path]],
     allPaths: Seq[Path],
-    stationIdsEntrance: Map[StationIds, Option[Entrance]],
-    timeMultiplier: Double
+    stationIdsEntrance: Map[StationIds, Option[Entrance]]
   ): Behavior[Command] =
     Behaviors.setup[Command] { context =>
 
       // UI actor
-      val ui = context.spawn(UI(timeMultiplier), "ui")
+      val ui = context.spawn(UI(), "ui")
 
       // Line actors
       val lineActors: Map[String, ActorRef[LineMessage]] = sortedLinePaths.keys.map { l =>
@@ -162,7 +174,7 @@ object Guardian {
         for (_ <- 1 to trainCount) {
           val start = platforms(random.nextInt(platforms.size))
           val uuid = java.util.UUID.randomUUID.toString
-          val train = context.spawn(Train(ui, allPaths, timeMultiplier), uuid)
+          val train = context.spawn(Train(ui, allPaths), uuid)
           train ! Move(start)
         }
       }
@@ -172,7 +184,7 @@ object Guardian {
         stationActors.values.toList ++ allPlatformActors.values.toList
 
       context.spawn(
-        Simulator(ui, allStationAndPlatformActors, metroGraph, stationIdsEntrance, timeMultiplier),
+        Simulator(ui, allStationAndPlatformActors, metroGraph, stationIdsEntrance),
         "simulator"
       )
 

--- a/metro-sim/src/main/scala/Person.scala
+++ b/metro-sim/src/main/scala/Person.scala
@@ -1,7 +1,5 @@
 // Metro. SDMT
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration, SECONDS}
-
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
 import org.apache.pekko.actor.typed.scaladsl.Behaviors
 
@@ -10,16 +8,16 @@ import messages.Messages._
 
 object Person {
 
+  // Retry delays in simulation milliseconds
+  private val RetryMs = 5_000L
+
   def apply(
     simulator: ActorRef[SimulatorMessage],
-    path: Seq[ActorRef[_]],
-    timeMultiplier: Double
+    path: Seq[ActorRef[_]]
   ): Behavior[PersonMessage] =
     Behaviors.setup { context =>
-      val waitAtStation: FiniteDuration  = FiniteDuration((5 * timeMultiplier).toLong, SECONDS)
-      val waitForStation: FiniteDuration = FiniteDuration((5 * timeMultiplier).toLong, SECONDS)
-      val waitAtPlatform: FiniteDuration = FiniteDuration((5 * timeMultiplier).toLong, SECONDS)
       val personName = context.self.path.name
+      val selfRef    = context.self
 
       def isStation(ref: ActorRef[_]): Boolean = ref.path.name.startsWith(Metro.StationPrefix)
 
@@ -33,7 +31,7 @@ object Person {
 
       // Start: request entry into first node (always a station)
       scribe.debug(s"Person $personName to ${path.last.path.name} wants to enter ${path.head.path.name}")
-      stationRef(path.head) ! RequestEnterStation(context.self)
+      stationRef(path.head) ! RequestEnterStation(selfRef)
 
       def initial(): Behavior[PersonMessage] =
         Behaviors.receiveMessage {
@@ -43,18 +41,17 @@ object Person {
             if (idx >= path.size) {
               scribe.debug(s"Person $personName arrived final destination")
               station ! ExitStation(personName)
-              simulator ! ArrivedToDestination(context.self)
+              simulator ! ArrivedToDestination(selfRef)
               Behaviors.stopped
             } else {
               val next = path(idx)
-              if (isStation(next)) stationRef(next) ! RequestEnterStation(context.self)
-              else platformRef(next) ! RequestEnterPlatform(context.self)
+              if (isStation(next)) stationRef(next) ! RequestEnterStation(selfRef)
+              else platformRef(next) ! RequestEnterPlatform(selfRef)
               inStation(station)
             }
 
           case NotAcceptedEnterStation =>
-            context.system.scheduler.scheduleOnce(waitForStation, () =>
-              stationRef(path.head) ! RequestEnterStation(context.self))(context.executionContext)
+            SimClock.scheduleIn(RetryMs) { () => stationRef(path.head) ! RequestEnterStation(selfRef) }
             Behaviors.same
 
           case _ => Behaviors.same
@@ -70,12 +67,12 @@ object Person {
             if (idx >= path.size) {
               scribe.debug(s"Person $personName arrived final destination")
               newStation ! ExitStation(personName)
-              simulator ! ArrivedToDestination(context.self)
+              simulator ! ArrivedToDestination(selfRef)
               Behaviors.stopped
             } else {
               val next = path(idx)
-              if (isStation(next)) stationRef(next) ! RequestEnterStation(context.self)
-              else platformRef(next) ! RequestEnterPlatform(context.self)
+              if (isStation(next)) stationRef(next) ! RequestEnterStation(selfRef)
+              else platformRef(next) ! RequestEnterPlatform(selfRef)
               inStation(newStation)
             }
 
@@ -85,10 +82,10 @@ object Person {
             inPlatform(platform, path(nextNodeIndex(platform)))
 
           case NotAcceptedEnterPlatform =>
-            context.system.scheduler.scheduleOnce(waitAtStation, () => {
+            SimClock.scheduleIn(RetryMs) { () =>
               val idx = nextNodeIndex(currentStation)
-              if (idx < path.size) platformRef(path(idx)) ! RequestEnterPlatform(context.self)
-            })(context.executionContext)
+              if (idx < path.size) platformRef(path(idx)) ! RequestEnterPlatform(selfRef)
+            }
             Behaviors.same
 
           case _ => Behaviors.same
@@ -99,7 +96,7 @@ object Person {
 
           case TrainInPlatform(train) =>
             scribe.debug(s"Train ${train.path.name} available at ${currentPlatform.path.name}")
-            train ! RequestEnterTrain(context.self)
+            train ! RequestEnterTrain(selfRef)
             Behaviors.same
 
           case AcceptedEnterTrain(platform) =>
@@ -109,7 +106,6 @@ object Person {
 
           case NotAcceptedEnterTrain =>
             scribe.debug(s"Person $personName not accepted in train")
-            // retry — the train will re-check capacity
             Behaviors.same
 
           case AcceptedEnterStation(station) =>
@@ -117,12 +113,12 @@ object Person {
             val idx = nextNodeIndex(station)
             if (idx >= path.size) {
               station ! ExitStation(personName)
-              simulator ! ArrivedToDestination(context.self)
+              simulator ! ArrivedToDestination(selfRef)
               Behaviors.stopped
             } else {
               val next = path(idx)
-              if (isStation(next)) stationRef(next) ! RequestEnterStation(context.self)
-              else platformRef(next) ! RequestEnterPlatform(context.self)
+              if (isStation(next)) stationRef(next) ! RequestEnterStation(selfRef)
+              else platformRef(next) ! RequestEnterPlatform(selfRef)
               inStation(station)
             }
 
@@ -136,13 +132,11 @@ object Person {
             scribe.debug(s"Person $personName at platform ${platform.path.name}")
             val idx = nextNodeIndex(platform)
             if (idx < path.size && isStation(path(idx))) {
-              // Next stop is a station — disembark
               scribe.debug(s"Person $personName disembarking at ${platform.path.name}")
-              platform ! EnteredPlatformFromTrain(context.self)
-              stationRef(path(idx)) ! RequestEnterStation(context.self)
+              platform ! EnteredPlatformFromTrain(selfRef)
+              stationRef(path(idx)) ! RequestEnterStation(selfRef)
               inPlatform(platform, path(idx))
             } else {
-              // Stay on train
               Behaviors.same
             }
 

--- a/metro-sim/src/main/scala/SimClock.scala
+++ b/metro-sim/src/main/scala/SimClock.scala
@@ -1,0 +1,95 @@
+// Metro. SDMT
+// Discrete-Event Simulation clock.
+//
+// Replaces Akka wall-clock timers with a priority-queue event loop that runs
+// purely in simulation time. One dedicated daemon thread advances simTimeMs by
+// speedFactor for every real millisecond elapsed, firing all events whose
+// scheduled time has been reached.
+//
+// Usage from any thread (actor or otherwise):
+//   SimClock.scheduleIn(delaySimMs) { () => someActor ! SomeMessage }
+//   SimClock.scheduleAt(absSimMs)   { () => someActor ! SomeMessage }
+//
+// Speed is expressed as "sim-milliseconds per real-millisecond":
+//   speedFactor = 10  → simulation runs 10× faster than real time
+//   speedFactor = 100 → 100× faster (100 sim-seconds per real-second)
+
+object SimClock {
+
+  // ── Event ────────────────────────────────────────────────────────────────
+
+  private final class Event(val atSimMs: Long, val run: () => Unit)
+    extends Comparable[Event] {
+    def compareTo(other: Event): Int = java.lang.Long.compare(atSimMs, other.atSimMs)
+  }
+
+  // ── State ────────────────────────────────────────────────────────────────
+
+  private val queue = new java.util.concurrent.PriorityBlockingQueue[Event]()
+
+  @volatile private var _simTimeMs: Long   = 6L * 3600L * 1000L  // starts at 06:00
+  @volatile private var _speedFactor: Double = 10.0               // default: 10× real time
+  @volatile private var _running: Boolean  = false
+
+  def simTimeMs:   Long   = _simTimeMs
+  def speedFactor: Double = _speedFactor
+
+  // ── Public API ───────────────────────────────────────────────────────────
+
+  /** Schedule a callback at an absolute simulation time. */
+  def scheduleAt(atSimMs: Long)(run: () => Unit): Unit =
+    queue.offer(new Event(atSimMs, run))
+
+  /** Schedule a callback at simNow + delaySimMs. */
+  def scheduleIn(delaySimMs: Long)(run: () => Unit): Unit =
+    scheduleAt(_simTimeMs + delaySimMs)(run)
+
+  /** Change simulation speed. Thread-safe; takes effect on next tick. */
+  def setSpeed(factor: Double): Unit = {
+    _speedFactor = factor.max(0.1).min(10_000.0)
+  }
+
+  /** Reset simulation clock to 06:00 and clear pending events. */
+  def reset(): Unit = {
+    queue.clear()
+    _simTimeMs = 6L * 3600L * 1000L
+  }
+
+  // ── Event loop ───────────────────────────────────────────────────────────
+
+  def start(): Unit = {
+    _running = true
+    val thread = new Thread(() => {
+      var lastRealMs = System.currentTimeMillis()
+      while (_running) {
+        val nowMs      = System.currentTimeMillis()
+        val realDelta  = (nowMs - lastRealMs).max(0L)
+        lastRealMs     = nowMs
+
+        val targetSimMs = _simTimeMs + (realDelta * _speedFactor).toLong
+
+        // Fire all events due by targetSimMs
+        var continue = true
+        while (continue) {
+          val next = queue.peek()
+          if (next != null && next.atSimMs <= targetSimMs) {
+            queue.poll()
+            _simTimeMs = next.atSimMs
+            try { next.run() }
+            catch { case ex: Throwable => scribe.error(s"SimClock event error: $ex") }
+          } else {
+            continue = false
+          }
+        }
+        _simTimeMs = targetSimMs
+
+        Thread.sleep(1)
+      }
+    }, "sim-clock")
+    thread.setDaemon(true)
+    thread.start()
+    scribe.info(s"SimClock started at speedFactor=${_speedFactor}×")
+  }
+
+  def stop(): Unit = { _running = false }
+}

--- a/metro-sim/src/main/scala/Simulator.scala
+++ b/metro-sim/src/main/scala/Simulator.scala
@@ -1,6 +1,6 @@
 // Metro. SDMT
 
-import scala.concurrent.duration.{DurationDouble, DurationInt}
+import scala.concurrent.duration.DurationInt
 import scala.util.Random
 
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
@@ -21,25 +21,24 @@ object Simulator {
     21 -> 5, 22 -> 3, 23 -> 2
   )
 
-  private val TimeStep = 10
+  // Sim-time step between person-spawning ticks (10 sim-seconds)
+  private val TimeStepMs = 10_000L
 
   def apply(
     ui: ActorRef[UIMessage],
     stationActors: List[ActorRef[_]],
     metroGraph: Graph[MetroNode, WDiEdge],
-    stationIdsEntrance: Map[StationIds, Option[Entrance]],
-    timeMultiplier: Double
+    stationIdsEntrance: Map[StationIds, Option[Entrance]]
   ): Behavior[SimulatorMessage] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
-        timers.startTimerWithFixedDelay("simulate-tick", SimulateStep,
-          1.second, (TimeStep * timeMultiplier).seconds)
+        // Stats tick: real-time, just for WebSocket reporting
         timers.startTimerWithFixedDelay("stats-tick", SimulatorStatsTick, 3.seconds, 1.second)
 
         val people: scala.collection.mutable.Map[String, ActorRef[PersonMessage]] =
           scala.collection.mutable.Map.empty
         var simulationPeople: Int = 0
-        var time: Long = 6 * 3600 * 1000
+        val selfRef = context.self
 
         val random = new Random
 
@@ -47,6 +46,9 @@ object Simulator {
           .nodes
           .filter(x => x.value.name.startsWith(Metro.StationPrefix))
           .toList
+
+        // Kick off the first SimulateStep via SimClock
+        SimClock.scheduleIn(TimeStepMs) { () => selfRef ! SimulateStep }
 
         Behaviors.receiveMessage {
 
@@ -56,17 +58,20 @@ object Simulator {
             Behaviors.same
 
           case SimulateStep =>
-            time += TimeStep * 1000
-            scribe.info(s"Simulator issuing Persons, time multiplier $timeMultiplier")
+            val simTimeMs = SimClock.simTimeMs
+            scribe.info(s"Simulator step at sim-time ${simTimeMs / 1000}s (${people.size} active people)")
+
             for {
               startNode <- stations
               startStationId <- stationIdsEntrance
                 .filter { case (k, _) => startNode.value.name.contains(k.name) }
                 .values.flatten
               dailyEntrance: Double = startStationId.entrance / 30.0
-              hourKey = (24 * (time.toDouble / (86400.0 * 1000))).toInt
+              // Hour derived from sim-clock, not wall clock
+              hourKey = ((simTimeMs.toDouble / 3_600_000.0) % 24).toInt
               hourMultiplier: Double = HourDistribution.getOrElse(hourKey, 0.0)
-              peopleCount: Double = (dailyEntrance / (86400.0 * timeMultiplier) +
+              // People to spawn this tick: proportional to sim-time step
+              peopleCount: Double = (dailyEntrance * TimeStepMs / 86_400_000.0 +
                 startNode.partialPerson) * hourMultiplier
               integerPart: Int = peopleCount.toInt
               floatPart: Double = peopleCount - integerPart
@@ -79,10 +84,13 @@ object Simulator {
                 .map(x => stationActors.filter(y => y.path.name == x.name).head)
                 .toSeq
               uuid = java.util.UUID.randomUUID.toString
-              person = context.spawn(Person(context.self, path, timeMultiplier), uuid)
+              person = context.spawn(Person(selfRef, path), uuid)
               _ = people(person.path.name) = person
               _ = simulationPeople += 1
             } yield ()
+
+            // Schedule the next tick in simulation time (self-rescheduling)
+            SimClock.scheduleIn(TimeStepMs) { () => selfRef ! SimulateStep }
             Behaviors.same
 
           case ArrivedToDestination(person) =>

--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -1,6 +1,5 @@
 // Metro. SDMT
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration, SECONDS}
 import scala.util.Random
 
 import org.apache.pekko.actor.typed.{ActorRef, Behavior}
@@ -15,14 +14,23 @@ object Train {
 
   private val MAX_CAPACITY = 1000
 
-  def apply(ui: ActorRef[UIMessage], allPaths: Seq[Path], timeMultiplier: Double): Behavior[TrainMessage] =
+  // Delays in simulation milliseconds (no timeMultiplier — SimClock handles speed)
+  private val MinTravelMs = 90_000L
+  private val MaxTravelMs = 180_000L
+  private val MinDoorsMs  = 20_000L
+  private val MaxDoorsMs  = 40_000L
+  private val FullRetryMs = 30_000L
+
+  def apply(ui: ActorRef[UIMessage], allPaths: Seq[Path]): Behavior[TrainMessage] =
     Behaviors.setup { context =>
-      val timeBetweenPlatforms: FiniteDuration =
-        FiniteDuration((Random.between(90, 180) * timeMultiplier).toLong, SECONDS)
-      val timeOpenDoors: FiniteDuration =
-        FiniteDuration((Random.between(20, 40) * timeMultiplier).toLong, SECONDS)
+      val rng = new Random
+
+      def travelMs(): Long = MinTravelMs + rng.nextLong(MaxTravelMs - MinTravelMs)
+      def doorsMs():  Long = MinDoorsMs  + rng.nextLong(MaxDoorsMs  - MinDoorsMs)
 
       Behaviors.withTimers { timers =>
+        // Stats tick stays on real-time (only feeds WebSocket reporting)
+        import scala.concurrent.duration.DurationInt
         timers.startTimerWithFixedDelay("stats-tick", TrainStatsTick, 3.seconds, 1.second)
 
         val people: scala.collection.mutable.Map[String, ActorRef[PersonMessage]] =
@@ -33,6 +41,7 @@ object Train {
         var x: Double = 0
         var y: Double = 0
         val trainName = context.self.path.name
+        val selfRef   = context.self
 
         def findPlatformPath(p: ActorRef[PlatformMessage]): Option[Path] =
           allPaths.find(pp =>
@@ -46,7 +55,7 @@ object Train {
 
           case Move(p) =>
             scribe.debug(s"Train $trainName wants to move from ${p.path.name}")
-            p ! ReservePlatform(context.self)
+            p ! ReservePlatform(selfRef)
             Behaviors.same
 
           case PlatformReserved(p) =>
@@ -57,39 +66,39 @@ object Train {
                 x = pp.x; y = pp.y
                 WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, isNew = true)
               }
-              context.system.scheduler.scheduleOnce(timeBetweenPlatforms, () =>
-                platform.get ! GetNextPlatform(context.self))(context.executionContext)
+              SimClock.scheduleIn(travelMs()) { () =>
+                platform.foreach(_ ! GetNextPlatform(selfRef))
+              }
             } else {
               scribe.debug(s"Train $trainName departing from ${platform.get.path.name}")
               nextPlatform = Some(p)
               platform.get ! LeavingPlatform
-              context.system.scheduler.scheduleOnce(timeBetweenPlatforms, () =>
-                context.self ! TrainArrivedAtPlatform)(context.executionContext)
+              SimClock.scheduleIn(travelMs()) { () => selfRef ! TrainArrivedAtPlatform }
             }
             Behaviors.same
 
           case TrainArrivedAtPlatform =>
             scribe.debug(s"Train $trainName arriving at ${nextPlatform.get.path.name}")
             platform = nextPlatform
-            platform.get ! ArrivedAtPlatform(context.self)
+            platform.get ! ArrivedAtPlatform(selfRef)
             people.foreach { case (_, person) => person ! ArrivedAtPlatformToPeople(platform.get) }
             findPlatformPath(platform.get).foreach { pp => x = pp.x; y = pp.y }
             WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, isNew = false)
             nextPlatform = None
-            context.system.scheduler.scheduleOnce(timeOpenDoors, () =>
-              platform.get ! GetNextPlatform(context.self))(context.executionContext)
+            SimClock.scheduleIn(doorsMs()) { () =>
+              platform.foreach(_ ! GetNextPlatform(selfRef))
+            }
             Behaviors.same
 
           case NextPlatformForTrain(p) =>
             nextPlatform = Some(p)
             scribe.debug(s"Train $trainName knows next platform ${p.path.name}")
-            p ! ReservePlatform(context.self)
+            p ! ReservePlatform(selfRef)
             Behaviors.same
 
           case FullPlatform(p) =>
             scribe.debug(s"Train $trainName waiting — platform ${p.path.name} full")
-            context.system.scheduler.scheduleOnce(5.seconds, () =>
-              p ! ReservePlatform(context.self))(context.executionContext)
+            SimClock.scheduleIn(FullRetryMs) { () => p ! ReservePlatform(selfRef) }
             Behaviors.same
 
           case RequestEnterTrain(person) =>

--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -11,21 +11,17 @@ import utils.WebSocket
 
 object UI {
 
-  def apply(timeMultiplier: Double): Behavior[UIMessage] =
+  def apply(): Behavior[UIMessage] =
     Behaviors.withTimers { timers =>
       timers.startTimerWithFixedDelay("trains-tick", UITrainsTick, 3.seconds, 1.second)
       timers.startTimerWithFixedDelay("simtime-tick", UISimTimeTick, 0.seconds, 1.second)
-
-      val simStartMs  = 6L * 3600L * 1000L          // simulation starts at 06:00
-      val realStartMs = System.currentTimeMillis()
 
       val trains: scala.collection.mutable.Map[String, Int] = scala.collection.mutable.Map.empty
 
       Behaviors.receiveMessage {
 
         case UISimTimeTick =>
-          val elapsed = System.currentTimeMillis() - realStartMs
-          val simMs   = simStartMs + (elapsed.toDouble / timeMultiplier).toLong
+          val simMs = SimClock.simTimeMs
           WebSocket.sendStat("simTime", s"""{"message": "simTime", "ms": $simMs}""")
           Behaviors.same
 

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -472,8 +472,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.cfg.save({ ...this.cfg.config, [field]: next });
   }
 
-  speedDown(): void { this.speedIdx = Math.max(0, this.speedIdx - 1); }
-  speedUp():   void { this.speedIdx = Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1); }
+  speedDown(): void {
+    this.speedIdx = Math.max(0, this.speedIdx - 1);
+    this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
+  }
+  speedUp(): void {
+    this.speedIdx = Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1);
+    this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
+  }
 
   resetSimulation(): void {
     const [h, m] = this.resetTime.split(':').map(Number);


### PR DESCRIPTION
## What changes and why

The previous simulation was **wall-clock driven**: every delay (`timeBetweenPlatforms`, `waitAtStation`, etc.) was an Akka timer that waited real operating-system seconds. Speed was limited by `timeMultiplier` in config and could not be changed at runtime. The frontend's speed stepper only moved the clock display — it had no effect on actual simulation throughput.

This PR replaces all wall-clock timers with a **discrete event simulation** engine (`SimClock`).

## SimClock

```
metro-sim/src/main/scala/SimClock.scala  (new)
```

- **Priority queue** (`PriorityBlockingQueue[Event]`) ordered by simulation timestamp
- **Dedicated daemon thread** that sleeps 1 real ms per iteration, advancing `simTimeMs` by `speedFactor` sim-ms per real-ms
- **Thread-safe**: volatile fields + concurrent queue; callbacks send Akka messages (safe from any thread)
- **Speed control**: `SimClock.setSpeed(factor)` — takes effect on the next tick with no actor restart

```scala
SimClock.setSpeed(100.0)          // 100× faster than real time
SimClock.scheduleIn(90_000L) {    // fire in 90 sim-seconds
  () => selfRef ! TrainArrivedAtPlatform
}
```

## What replaced what

| Before | After |
|--------|-------|
| `context.system.scheduler.scheduleOnce(timeBetweenPlatforms * TM, ...)` | `SimClock.scheduleIn(90_000L) { () => ... }` |
| `FiniteDuration((90 * timeMultiplier).toLong, SECONDS)` | `90_000L` (plain sim-ms, no TM scaling) |
| `timers.startTimerWithFixedDelay("simulate-tick", ..., (10 * TM).seconds)` | `SimClock.scheduleIn(10_000L) { () => selfRef ! SimulateStep }` + self-reschedule |
| `timeMultiplier` passed to every actor constructor | Removed — only `SimClock` knows about speed |
| Wall-clock sim-time calculation in `UI` | `SimClock.simTimeMs` directly |

Stats tickers (`TrainStatsTick`, `PlatformStatsTick`, `SimulatorStatsTick`) remain on real-time Akka timers — they only feed WebSocket reporting, not simulation logic.

## Frontend speed control now works end-to-end

The speed stepper buttons in the left panel now send `{"message": "setSpeed", "factor": N}` to the backend:

```
×0.25 → ×0.5 → ×1 → ×2 → ×5 → ×10 → ×20
```

The backend:
1. Calls `SimClock.setSpeed(factor)` — changes simulation throughput immediately
2. Broadcasts new `timeMultiplier = 1/factor` to all clients
3. All pending events in the queue respect the new speed from the next tick

The frontend syncs its clock from `simTime` messages (sent every real second from `UI`), so the display stays accurate at any speed.

## Reset now resets the sim-clock too

`WebSocket.resetSnapshot()` now also calls `SimClock.reset()`, which clears the event queue and resets `simTimeMs` to 06:00.