### PR TITLE
feat: CPU load monitor for SimClock saturation

### DIFF
--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -23,6 +23,9 @@ object UI {
         case UISimTimeTick =>
           val simMs = SimClock.simTimeMs
           WebSocket.sendStat("simTime", s"""{"message": "simTime", "ms": $simMs}""")
+          val load = SimClock.tickLoad
+          WebSocket.sendStat("simLoad",
+            s"""{"message": "simLoad", "load": $load, "eventsPerTick": ${SimClock.eventsPerTick}, "queueSize": ${SimClock.queueSize}}""")
           Behaviors.same
 
         case UITrainsTick =>

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -69,6 +69,13 @@ export interface ResetAck {
   message: 'reset';
 }
 
+export interface SimLoad {
+  message: 'simLoad';
+  load: number;
+  eventsPerTick: number;
+  queueSize: number;
+}
+
 export type SimulationMessage =
   | MoveTrain
   | PeopleInLinePlatforms
@@ -81,4 +88,5 @@ export type SimulationMessage =
   | PlatformOvercrowded
   | StationOvercrowded
   | SimTime
-  | ResetAck;
+  | ResetAck
+  | SimLoad;

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -15,6 +15,9 @@ export class SimulationStateService {
   metroPeople = 0;
   trainsPeople = 0;
   timeMultiplier = 1;
+  simLoad = 0;
+  eventsPerTick = 0;
+  queueSize = 0;
 
   readonly platformsPeople = new Map<string, number>();
   readonly stationsPeople = new Map<string, number>();
@@ -93,6 +96,11 @@ export class SimulationStateService {
         break;
       case 'stationOvercrowded':
         console.warn(`Station overcrowded: ${msg.platform} with ${msg.people}`);
+        break;
+      case 'simLoad':
+        this.simLoad = msg.load;
+        this.eventsPerTick = msg.eventsPerTick;
+        this.queueSize = msg.queueSize;
         break;
     }
   }

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -309,6 +309,32 @@
   font-size: 13px;
 }
 
+/* ── CPU load indicator ──────────────────────────────────── */
+.load-indicator {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.load-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  transition: background 0.4s;
+}
+
+.load-ok   { background: #3fb950; }
+.load-warn { background: #d29922; }
+.load-over { background: #f85149; }
+
+.load-val {
+  font-size: 12px;
+  font-weight: 600;
+  color: #e6edf3;
+}
+
 /* ── Zoom indicator (dev only) ───────────────────────────── */
 .zoom-indicator {
   position: absolute;

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -79,6 +79,26 @@
           </button>
         </div>
 
+        <div class="panel-divider"></div>
+
+        <div class="panel-section">
+          <span class="panel-label">CPU LOAD</span>
+          <div class="load-indicator">
+            <div class="load-dot" [class.load-ok]="state.simLoad <= 0.7"
+                                  [class.load-warn]="state.simLoad > 0.7 && state.simLoad <= 1.0"
+                                  [class.load-over]="state.simLoad > 1.0"></div>
+            <span class="load-val">{{ (state.simLoad * 100).toFixed(0) }}%</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-name">Events/tick</span>
+            <span class="stat-val">{{ state.eventsPerTick }}</span>
+          </div>
+          <div class="stat-row">
+            <span class="stat-name">Queue</span>
+            <span class="stat-val">{{ state.queueSize }}</span>
+          </div>
+        </div>
+
       </div>
     }
   </aside>


### PR DESCRIPTION
## Summary

- `UI.scala` now broadcasts a `simLoad` WebSocket message every second alongside `simTime`, exposing `tickLoad` (EMA of real-ms per tick), `eventsPerTick`, and `queueSize` from `SimClock`
- New `SimLoad` interface added to `messages.ts` and handled in `SimulationStateService`
- Left panel shows a **CPU LOAD** section with a colour-coded dot (green ≤70%, yellow ≤100%, red >100%) so the user can instantly see if the simulation is falling behind real time

## How to read the indicator

| Colour | Meaning |
|--------|---------|
| green | SimClock tick < 0.7 ms — comfortable headroom |
| yellow | Tick approaching 1 ms nominal — watch it |
| red | Tick > 1 ms — simulation is falling behind, reduce speed |

## Test plan

- [ ] Start backend + frontend, verify CPU LOAD section appears in left panel
- [ ] Raise speedFactor until overloaded; dot should turn yellow then red
- [ ] Lower speedFactor; dot recovers to green within a few seconds (EMA lag)