### PR TITLE
fix: SimClock tickLoad always showed 100% on idle

### DIFF
--- a/metro-sim/src/main/scala/SimClock.scala
+++ b/metro-sim/src/main/scala/SimClock.scala
@@ -33,7 +33,7 @@ object SimClock {
 
   // ── Load metrics (updated every tick) ───────────────────────────────────
   // Exponential moving average of tick duration in ms (α = 0.05). Nominal = 1.0.
-  @volatile private var _tickDurationEma: Double = 1.0
+  @volatile private var _tickDurationEma: Double = 0.0
   // Events processed in the last tick
   @volatile private var _eventsPerTick:   Int    = 0
 
@@ -101,7 +101,7 @@ object SimClock {
         _eventsPerTick = fired
 
         // Update EMA of tick duration
-        val tickDuration = (System.currentTimeMillis() - tickStart).max(1L).toDouble
+        val tickDuration = (System.currentTimeMillis() - tickStart).toDouble
         _tickDurationEma = Alpha * tickDuration + (1 - Alpha) * _tickDurationEma
 
         Thread.sleep(1)


### PR DESCRIPTION
## Problem

CPU LOAD indicator always showed ~100% even at ×1 speed with 0 events.

## Root cause

`.max(1L)` in the tick duration measurement forced a minimum of 1 ms of
reported processing time. Since the nominal tick budget is 1 ms, this
always produced a load of 1.0 (100%) regardless of actual CPU usage.

## Fix

- Remove `.max(1L)` so idle ticks (0 ms processing) report 0% load
- Initialise `_tickDurationEma` to 0.0 instead of 1.0

Now: idle = ~0%, busy = proportional to actual processing time, >100% = overloaded.