### PR TITLE
feat: play/pause from frontend + fix ×1 real-time speed

### DIFF
--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -72,11 +72,17 @@ object Main {
     // Start WebSocket HTTP server using classic adapter
     implicit val classicSystem: org.apache.pekko.actor.ActorSystem = system.toClassic
     import classicSystem.dispatcher
+    def broadcastPaused(): Unit = {
+      val p = SimClock.isPaused
+      WebSocket.sendStat("simPaused", s"""{"message": "simPaused", "paused": $p}""")
+    }
+
     // Register command handler for messages from the browser
     WebSocket.setCommandHandler { text =>
       if (text.contains("\"reset\"")) {
         SimClock.reset()
         WebSocket.resetSnapshot()
+        broadcastPaused()
       } else if (text.contains("\"setSpeed\"")) {
         val factor = text.split("\"factor\"\\s*:\\s*").drop(1).headOption
           .flatMap(_.trim.takeWhile(c => c.isDigit || c == '.').toDoubleOption)
@@ -84,6 +90,12 @@ object Main {
         SimClock.setSpeed(factor)
         val tm = 1.0 / SimClock.speedFactor
         WebSocket.sendStat("timeMultiplier", s"""{"message": "timeMultiplier", "multiplier": $tm}""")
+      } else if (text.contains("\"pause\"")) {
+        SimClock.pause()
+        broadcastPaused()
+      } else if (text.contains("\"resume\"")) {
+        SimClock.resume()
+        broadcastPaused()
       }
     }
 

--- a/metro-sim/src/main/scala/SimClock.scala
+++ b/metro-sim/src/main/scala/SimClock.scala
@@ -33,7 +33,7 @@ object SimClock {
 
   // ── Load metrics (updated every tick) ───────────────────────────────────
   // Exponential moving average of tick duration in ms (α = 0.05). Nominal = 1.0.
-  @volatile private var _tickDurationEma: Double = 1.0
+  @volatile private var _tickDurationEma: Double = 0.0
   // Events processed in the last tick
   @volatile private var _eventsPerTick:   Int    = 0
 
@@ -101,7 +101,7 @@ object SimClock {
         _eventsPerTick = fired
 
         // Update EMA of tick duration
-        val tickDuration = (System.currentTimeMillis() - tickStart).max(1L).toDouble
+        val tickDuration = (System.currentTimeMillis() - tickStart).toDouble
         _tickDurationEma = Alpha * tickDuration + (1 - Alpha) * _tickDurationEma
 
         Thread.sleep(1)

--- a/metro-sim/src/main/scala/SimClock.scala
+++ b/metro-sim/src/main/scala/SimClock.scala
@@ -30,6 +30,11 @@ object SimClock {
   @volatile private var _simTimeMs:       Long    = 6L * 3600L * 1000L  // starts at 06:00
   @volatile private var _speedFactor:     Double  = 10.0               // default: 10× real time
   @volatile private var _running:         Boolean = false
+  @volatile private var _paused:          Boolean = false
+
+  def isPaused: Boolean = _paused
+  def pause():  Unit    = { _paused = true }
+  def resume(): Unit    = { _paused = false }
 
   // ── Load metrics (updated every tick) ───────────────────────────────────
   // Exponential moving average of tick duration in ms (α = 0.05). Nominal = 1.0.
@@ -62,10 +67,11 @@ object SimClock {
     _speedFactor = factor.max(0.1).min(10_000.0)
   }
 
-  /** Reset simulation clock to 06:00 and clear pending events. */
+  /** Reset simulation clock to 06:00, clear pending events, and pause. */
   def reset(): Unit = {
     queue.clear()
     _simTimeMs = 6L * 3600L * 1000L
+    _paused = true
   }
 
   // ── Event loop ───────────────────────────────────────────────────────────
@@ -76,31 +82,33 @@ object SimClock {
     val thread = new Thread(() => {
       var lastRealMs = System.currentTimeMillis()
       while (_running) {
-        val tickStart  = System.currentTimeMillis()
-        val realDelta  = (tickStart - lastRealMs).max(0L)
-        lastRealMs     = tickStart
+        val tickStart = System.currentTimeMillis()
+        val realDelta = (tickStart - lastRealMs).max(0L)
+        lastRealMs    = tickStart  // always advance to avoid time-jump on resume
 
-        val targetSimMs = _simTimeMs + (realDelta * _speedFactor).toLong
         var fired = 0
+        if (!_paused) {
+          val targetSimMs = _simTimeMs + (realDelta * _speedFactor).toLong
 
-        // Fire all events due by targetSimMs
-        var continue = true
-        while (continue) {
-          val next = queue.peek()
-          if (next != null && next.atSimMs <= targetSimMs) {
-            queue.poll()
-            _simTimeMs = next.atSimMs
-            fired += 1
-            try { next.run() }
-            catch { case ex: Throwable => scribe.error(s"SimClock event error: $ex") }
-          } else {
-            continue = false
+          // Fire all events due by targetSimMs
+          var continue = true
+          while (continue) {
+            val next = queue.peek()
+            if (next != null && next.atSimMs <= targetSimMs) {
+              queue.poll()
+              _simTimeMs = next.atSimMs
+              fired += 1
+              try { next.run() }
+              catch { case ex: Throwable => scribe.error(s"SimClock event error: $ex") }
+            } else {
+              continue = false
+            }
           }
+          _simTimeMs = targetSimMs
         }
-        _simTimeMs    = targetSimMs
         _eventsPerTick = fired
 
-        // Update EMA of tick duration
+        // Update EMA of tick duration (only counts processing, not sleep)
         val tickDuration = (System.currentTimeMillis() - tickStart).toDouble
         _tickDurationEma = Alpha * tickDuration + (1 - Alpha) * _tickDurationEma
 

--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -26,6 +26,8 @@ object UI {
           val load = SimClock.tickLoad
           WebSocket.sendStat("simLoad",
             s"""{"message": "simLoad", "load": $load, "eventsPerTick": ${SimClock.eventsPerTick}, "queueSize": ${SimClock.queueSize}}""")
+          WebSocket.sendStat("simPaused",
+            s"""{"message": "simPaused", "paused": ${SimClock.isPaused}}""")
           Behaviors.same
 
         case UITrainsTick =>

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -76,6 +76,11 @@ export interface SimLoad {
   queueSize: number;
 }
 
+export interface SimPaused {
+  message: 'simPaused';
+  paused: boolean;
+}
+
 export type SimulationMessage =
   | MoveTrain
   | PeopleInLinePlatforms
@@ -89,4 +94,5 @@ export type SimulationMessage =
   | StationOvercrowded
   | SimTime
   | ResetAck
-  | SimLoad;
+  | SimLoad
+  | SimPaused;

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -15,6 +15,7 @@ export class SimulationStateService {
   metroPeople = 0;
   trainsPeople = 0;
   timeMultiplier = 1;
+  paused = false;
   simLoad = 0;
   eventsPerTick = 0;
   queueSize = 0;
@@ -49,7 +50,7 @@ export class SimulationStateService {
           train.targetX = msg.x;
           train.targetY = msg.y;
           train.departedAt = performance.now();
-          train.travelMs = 135_000 / this.timeMultiplier;
+          train.travelMs = 135_000 * this.timeMultiplier;
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
           this.dirty = true;
@@ -101,6 +102,9 @@ export class SimulationStateService {
         this.simLoad = msg.load;
         this.eventsPerTick = msg.eventsPerTick;
         this.queueSize = msg.queueSize;
+        break;
+      case 'simPaused':
+        this.paused = msg.paused;
         break;
     }
   }

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -283,6 +283,44 @@
   border-color: #58a6ff;
 }
 
+/* ── Simulation controls row (play + time + reset) ──────── */
+.sim-controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 4px;
+}
+
+.sim-controls .time-input {
+  flex: 1;
+  margin-top: 0;
+}
+
+/* ── Play/Pause button ───────────────────────────────────── */
+.play-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 6px;
+  color: #3fb950;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.play-btn:hover {
+  color: #58a6ff;
+  border-color: #58a6ff;
+}
+
+.play-btn .material-icons {
+  font-size: 16px;
+}
+
 /* ── Reset button ────────────────────────────────────────── */
 .reset-btn {
   display: flex;
@@ -298,6 +336,15 @@
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
   width: 100%;
+}
+
+.reset-btn.icon-only {
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  margin-top: 0;
+  padding: 0;
+  justify-content: center;
 }
 
 .reset-btn:hover {

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -67,16 +67,17 @@
 
         <div class="panel-section">
           <span class="panel-label">SIMULATION</span>
-          <div class="cfg-row">
-            <label class="cfg-label">Start time</label>
+          <div class="sim-controls">
+            <button class="play-btn" (click)="playPause()" [title]="state.paused ? 'Resume' : 'Pause'">
+              <span class="material-icons">{{ state.paused ? 'play_arrow' : 'pause' }}</span>
+            </button>
             <input class="time-input" type="time"
                    [value]="resetTime"
                    (change)="resetTime = $any($event.target).value">
+            <button class="reset-btn icon-only" (click)="resetSimulation()" title="Reset">
+              <span class="material-icons">restart_alt</span>
+            </button>
           </div>
-          <button class="reset-btn" (click)="resetSimulation()">
-            <span class="material-icons">restart_alt</span>
-            Reset
-          </button>
         </div>
 
         <div class="panel-divider"></div>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -96,6 +96,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.needsStaticRedraw = true;
     this.needsTrainRedraw  = true;
 
+    // Align backend speed with the frontend stepper on connect (×1 = real time)
+    this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
+
     this.wsService.messages$
       .pipe(takeUntil(this.destroy$))
       .subscribe(msg => {
@@ -269,9 +272,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       if (this.destroyed) return;
 
       // Advance simulation clock every frame (smooth)
+      // localSpeed IS the speedFactor sent to the backend, so 1 real-ms → localSpeed sim-ms.
       const dt = this.lastRafTimestamp > 0 ? timestamp - this.lastRafTimestamp : 0;
       this.lastRafTimestamp = timestamp;
-      this.time += dt * this.localSpeed / this.state.timeMultiplier;
+      if (!this.state.paused) {
+        this.time += dt * this.localSpeed;
+      }
 
       if (this.needsStaticRedraw) {
         this.drawPaths();
@@ -479,6 +485,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   speedUp(): void {
     this.speedIdx = Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1);
     this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
+  }
+
+  playPause(): void {
+    if (this.state.paused) {
+      this.wsService.send({ message: 'resume' });
+    } else {
+      this.wsService.send({ message: 'pause' });
+    }
   }
 
   resetSimulation(): void {


### PR DESCRIPTION
## Summary

- **Play/Pause button** in the SIMULATION section: green play icon while paused, white pause icon while running. Reset also pauses the simulation.
- **×1 = real time**: frontend sends `setSpeed: factor=1` on connect, forcing the backend to 1 sim-ms per real-ms. Speed stepper now directly maps to real-time multiples.
- **Clock formula fix**: was `dt * localSpeed / timeMultiplier` (effectively `dt * localSpeed²`); now `dt * localSpeed`. Clock also freezes while paused.
- **Animation duration fix**: `travelMs` was `135_000 / timeMultiplier` (22+ minutes at ×10); now `135_000 * timeMultiplier` (~13 seconds at ×10 — correct).

## Backend changes

- `SimClock`: `pause()` / `resume()` / `isPaused`; `reset()` now also pauses; `lastRealMs` always advances so no time jump on resume
- `Main`: handles `pause` / `resume` WebSocket commands; broadcasts `simPaused`
- `UI`: includes `simPaused` in the per-second snapshot for reconnecting clients

## Known limitation

After `reset`, actor self-scheduling loops are broken (trains/persons are mid-state). Full actor reset is tracked in issue #60.

## Test plan

- [ ] Click Pause — simulation clock freezes, trains stop moving
- [ ] Click Play — simulation resumes from where it left off, no time jump
- [ ] Click Reset — clock returns to chosen start time, simulation pauses
- [ ] At ×1 speed, verify 1 real minute = 1 minute on the sim clock
- [ ] Change to ×10, verify 1 real second ≈ 10 sim seconds on clock