### PR TITLE
fix: full actor reset on simulation restart

### DIFF
--- a/metro-sim/src/main/scala/CommandBus.scala
+++ b/metro-sim/src/main/scala/CommandBus.scala
@@ -1,0 +1,15 @@
+// Metro. SDMT
+// Thin singleton for routing commands from the WebSocket handler to the actor tree.
+// The WebSocket handler runs outside the actor system, so we use a registered callback
+// to bridge into the typed actor world without introducing shared mutable actor refs.
+
+object CommandBus {
+
+  @volatile private var _resetHandler: () => Unit = () => ()
+
+  /** Register the function to call when a reset command arrives. Called once at startup. */
+  def onReset(f: () => Unit): Unit = { _resetHandler = f }
+
+  /** Trigger a full simulation reset. Delegates to the registered handler. */
+  def fireReset(): Unit = _resetHandler()
+}

--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -82,6 +82,7 @@ object Main {
       if (text.contains("\"reset\"")) {
         SimClock.reset()
         WebSocket.resetSnapshot()
+        CommandBus.fireReset()
         broadcastPaused()
       } else if (text.contains("\"setSpeed\"")) {
         val factor = text.split("\"factor\"\\s*:\\s*").drop(1).headOption
@@ -177,17 +178,19 @@ object Guardian {
             }
         }
 
-      // Build trains
+      // Build trains — keep refs so we can reset them later
       val random = new Random
       val percentageOfStationsWithTrains = 80
-      platformActors.foreach { case (lineKey, linePlatforms) =>
+      val trainActors = scala.collection.mutable.Buffer[ActorRef[TrainMessage]]()
+      platformActors.foreach { case (_, linePlatforms) =>
         val platforms = linePlatforms.values.toSeq
         val trainCount = (percentageOfStationsWithTrains * platforms.length / 100) + 1
         for (_ <- 1 to trainCount) {
           val start = platforms(random.nextInt(platforms.size))
-          val uuid = java.util.UUID.randomUUID.toString
+          val uuid  = java.util.UUID.randomUUID.toString
           val train = context.spawn(Train(ui, allPaths), uuid)
           train ! Move(start)
+          trainActors += train
         }
       }
 
@@ -195,10 +198,22 @@ object Guardian {
       val allStationAndPlatformActors: List[ActorRef[_]] =
         stationActors.values.toList ++ allPlatformActors.values.toList
 
-      context.spawn(
+      val simulatorRef = context.spawn(
         Simulator(ui, allStationAndPlatformActors, metroGraph, stationIdsEntrance),
         "simulator"
       )
+
+      // Register CommandBus reset handler — called from WebSocket thread on reset command
+      val allPlatformSeq = allPlatformActors.values.toSeq
+      CommandBus.onReset { () =>
+        stationActors.values.foreach(_ ! ResetStation)
+        allPlatformActors.values.foreach(_ ! ResetPlatform)
+        trainActors.foreach { train =>
+          val p = allPlatformSeq(random.nextInt(allPlatformSeq.size))
+          train ! ResetTrain(p)
+        }
+        simulatorRef ! ResetSimulator
+      }
 
       Behaviors.empty[Command]
     }

--- a/metro-sim/src/main/scala/Platform.scala
+++ b/metro-sim/src/main/scala/Platform.scala
@@ -69,6 +69,10 @@ object Platform {
         people(person.path.name) = (person, false)
         Behaviors.same
 
+      case ResetPlatform =>
+        people.clear()
+        empty(self, line, name, next, people)
+
       case _ =>
         scribe.warn(s"Empty platform $name received unexpected message")
         Behaviors.same
@@ -123,6 +127,10 @@ object Platform {
       case EnteredPlatformFromTrain(person) =>
         people(person.path.name) = (person, false)
         Behaviors.same
+
+      case ResetPlatform =>
+        people.clear()
+        empty(self, line, name, next, people)
 
       case _ =>
         scribe.error(s"Full platform $name received unexpected message")

--- a/metro-sim/src/main/scala/Simulator.scala
+++ b/metro-sim/src/main/scala/Simulator.scala
@@ -97,6 +97,14 @@ object Simulator {
             scribe.debug(s"Person ${person.path.name} arrived to destination")
             people.remove(person.path.name)
             Behaviors.same
+
+          case ResetSimulator =>
+            scribe.info("Simulator resetting: stopping all persons")
+            people.values.foreach(context.stop)
+            people.clear()
+            simulationPeople = 0
+            SimClock.scheduleIn(TimeStepMs) { () => selfRef ! SimulateStep }
+            Behaviors.same
         }
       }
     }

--- a/metro-sim/src/main/scala/Station.scala
+++ b/metro-sim/src/main/scala/Station.scala
@@ -44,6 +44,10 @@ object Station {
           case ExitStation(personId) =>
             people.remove(personId)
             Behaviors.same
+
+          case ResetStation =>
+            people.clear()
+            Behaviors.same
         }
       }
     }

--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -115,6 +115,15 @@ object Train {
             scribe.debug(s"Person $personId exits train $trainName")
             people.remove(personId)
             Behaviors.same
+
+          case ResetTrain(startPlatform) =>
+            scribe.debug(s"Train $trainName resetting")
+            people.clear()
+            platform     = None
+            nextPlatform = None
+            x = 0; y = 0
+            startPlatform ! ReservePlatform(selfRef)
+            Behaviors.same
         }
       }
     }

--- a/metro-sim/src/main/scala/messages/Messages.scala
+++ b/metro-sim/src/main/scala/messages/Messages.scala
@@ -24,6 +24,7 @@ object Messages {
   case class ExitStation(personId: String) extends StationMessage
   case class EnteredStationFromPlatform(person: ActorRef[PersonMessage]) extends StationMessage
   case object StationStatsTick extends StationMessage
+  case object ResetStation extends StationMessage
 
   // ─── Platform messages (sent TO a Platform actor) ─────────────────────────
   sealed trait PlatformMessage
@@ -36,6 +37,7 @@ object Messages {
   case class GetNextPlatform(train: ActorRef[TrainMessage]) extends PlatformMessage
   case class SetNextPlatform(next: ActorRef[PlatformMessage]) extends PlatformMessage
   case object PlatformStatsTick extends PlatformMessage
+  case object ResetPlatform extends PlatformMessage
 
   // ─── Train messages (sent TO a Train actor) ───────────────────────────────
   sealed trait TrainMessage
@@ -47,6 +49,7 @@ object Messages {
   case class RequestEnterTrain(person: ActorRef[PersonMessage]) extends TrainMessage
   case class ExitTrain(personId: String) extends TrainMessage
   case object TrainStatsTick extends TrainMessage
+  case class ResetTrain(startPlatform: ActorRef[PlatformMessage]) extends TrainMessage
 
   // ─── Line messages (sent TO a Line actor) ─────────────────────────────────
   sealed trait LineMessage
@@ -71,4 +74,5 @@ object Messages {
   case object SimulateStep extends SimulatorMessage
   case class ArrivedToDestination(person: ActorRef[PersonMessage]) extends SimulatorMessage
   case object SimulatorStatsTick extends SimulatorMessage
+  case object ResetSimulator extends SimulatorMessage
 }


### PR DESCRIPTION
## Summary

- Adds `ResetStation`, `ResetPlatform`, `ResetTrain`, and `ResetSimulator` messages to each actor type
- Introduces a thin `CommandBus` singleton to bridge the WebSocket handler (outside the actor system) with the actor tree
- On reset command, all persons are stopped, queues cleared, and trains repositioned to random platforms

## Test plan

- [ ] Start the simulator and let it run for a while
- [ ] Send a reset command from the frontend and verify the simulation restarts cleanly
- [ ] Check that train positions reset and people counts go back to zero
- [ ] Verify no stale actors or state leaks after reset

Closes #60