### PR TITLE
feat: control room redesign — METRO OPS aesthetic

### DIFF
--- a/metro/angular.json
+++ b/metro/angular.json
@@ -41,8 +41,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "12kb",
+                  "maximumError": "20kb"
                 }
               ],
               "fileReplacements": [

--- a/metro/src/app/app.component.css
+++ b/metro/src/app/app.component.css
@@ -1,6 +1,9 @@
 .app-main {
-  position: relative;
+  flex: 1;
+  min-height: 0;
   overflow: hidden;
+  display: flex;
+  position: relative;
   background:
     linear-gradient(var(--line-1) 1px, transparent 1px) 0 0 / 80px 80px,
     linear-gradient(90deg, var(--line-1) 1px, transparent 1px) 0 0 / 80px 80px,

--- a/metro/src/app/app.component.css
+++ b/metro/src/app/app.component.css
@@ -1,5 +1,9 @@
 .app-main {
-  flex: 1;
+  position: relative;
   overflow: hidden;
-  display: flex;
+  background:
+    linear-gradient(var(--line-1) 1px, transparent 1px) 0 0 / 80px 80px,
+    linear-gradient(90deg, var(--line-1) 1px, transparent 1px) 0 0 / 80px 80px,
+    radial-gradient(ellipse 90% 60% at 50% 50%, #10141c 0%, var(--bg-0) 100%);
+  background-color: var(--bg-0);
 }

--- a/metro/src/app/config-dialog/config-dialog.component.css
+++ b/metro/src/app/config-dialog/config-dialog.component.css
@@ -1,34 +1,168 @@
-h2[mat-dialog-title] {
+.dialog {
+  width: 460px;
+  background: var(--bg-2);
+  border: 1px solid var(--line-3);
+  position: relative;
+  animation: slideup .22s ease;
+  font-family: var(--mono);
+}
+.dialog::before {
+  content: '';
+  position: absolute;
+  top: -1px; left: 0; right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--amber), transparent);
+}
+
+/* ── Head ──────────────────────────────────────────────────── */
+.dialog-head {
   display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--line-2);
+}
+.dialog-tag {
+  font-size: 9px;
+  letter-spacing: 0.32em;
+  color: var(--amber);
+  margin-bottom: 4px;
+}
+.dialog-title {
+  font-family: var(--sans);
+  font-size: 16px;
+  font-weight: 500;
+  color: var(--t-1);
+  letter-spacing: 0.04em;
+}
+.dialog-close {
+  background: none;
+  border: 1px solid var(--line-2);
+  width: 26px; height: 26px;
+  color: var(--t-3);
+  display: grid;
+  place-items: center;
+  transition: color .12s, border-color .12s;
+  flex-shrink: 0;
+}
+.dialog-close:hover { color: var(--crit); border-color: var(--crit); }
+.dialog-close svg { width: 12px; height: 12px; }
+
+/* ── Body ──────────────────────────────────────────────────── */
+.dialog-body { padding: 18px; }
+
+.field { margin-bottom: 16px; }
+.field-head {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+.field-label {
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--t-2);
+  font-weight: 500;
+}
+.field-range {
+  font-size: 9px;
+  color: var(--t-4);
+  letter-spacing: 0.08em;
+}
+.field-input {
+  display: grid;
+  grid-template-columns: 1fr 80px;
+  gap: 12px;
   align-items: center;
-  gap: 8px;
 }
-
-mat-dialog-content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  min-width: 340px;
-  padding-top: 8px !important;
-}
-
-.full-width {
+.field-input input[type=range] {
+  -webkit-appearance: none;
+  appearance: none;
   width: 100%;
+  height: 4px;
+  background: var(--line-1);
+  outline: none;
+  border-radius: 0;
 }
+.field-input input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 12px; height: 16px;
+  background: var(--amber);
+  cursor: pointer;
+}
+.field-input input[type=range]::-moz-range-thumb {
+  width: 12px; height: 16px;
+  background: var(--amber);
+  border: none;
+  border-radius: 0;
+}
+.field-input input[type=number] {
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--t-1);
+  font: 500 13px var(--mono);
+  height: 28px;
+  padding: 0 8px;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.field-input input[type=number]:focus { outline: none; border-color: var(--amber-dim); }
 
-.capacity-summary {
+/* ── Summary ────────────────────────────────────────────────── */
+.summary {
+  margin-top: 18px;
+  padding: 12px 14px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  border-left: 2px solid var(--amber);
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 8px 12px;
-  background: rgba(144, 202, 249, 0.1);
-  border-radius: 4px;
-  font-size: 0.9rem;
-  color: #90caf9;
+  justify-content: space-between;
 }
+.summary .k {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--t-3);
+}
+.summary-formula {
+  font-size: 9px;
+  color: var(--t-4);
+  letter-spacing: 0.12em;
+  margin-top: 2px;
+}
+.summary .v {
+  font-family: var(--sans);
+  font-size: 22px;
+  color: var(--amber);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+}
+.summary .unit { font-size: 11px; color: var(--t-3); margin-left: 6px; }
 
-.capacity-summary mat-icon {
-  font-size: 18px;
-  width: 18px;
-  height: 18px;
+/* ── Footer ─────────────────────────────────────────────────── */
+.dialog-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 18px;
+  border-top: 1px solid var(--line-2);
+  background: var(--bg-1);
 }
+.btn {
+  padding: 0 18px;
+  height: 30px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-3);
+  color: var(--t-2);
+  font: 500 11px var(--mono);
+  letter-spacing: 0.16em;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.btn:hover { color: var(--t-1); border-color: var(--t-3); }
+.btn-primary {
+  background: var(--amber);
+  border-color: var(--amber);
+  color: var(--bg-0);
+  font-weight: 600;
+}
+.btn-primary:hover { background: var(--amber-dim); border-color: var(--amber-dim); color: var(--bg-0); }
+.btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }

--- a/metro/src/app/config-dialog/config-dialog.component.html
+++ b/metro/src/app/config-dialog/config-dialog.component.html
@@ -1,44 +1,69 @@
-<h2 mat-dialog-title>
-  <mat-icon>settings</mat-icon>
-  Simulation configuration
-</h2>
-
-<mat-dialog-content [formGroup]="form">
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Wagon capacity (people per wagon)</mat-label>
-    <input matInput type="number" formControlName="wagonCapacity" min="1" max="500">
-    @if (form.get('wagonCapacity')?.invalid) {
-      <mat-error>Enter a value between 1 and 500</mat-error>
-    }
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Wagons per train</mat-label>
-    <input matInput type="number" formControlName="wagonsPerTrain" min="1" max="20">
-    @if (form.get('wagonsPerTrain')?.invalid) {
-      <mat-error>Enter a value between 1 and 20</mat-error>
-    }
-  </mat-form-field>
-
-  <mat-form-field appearance="outline" class="full-width">
-    <mat-label>Trains per quarter hour (per line)</mat-label>
-    <input matInput type="number" formControlName="trainsPerQuarterHour" min="1" max="30">
-    @if (form.get('trainsPerQuarterHour')?.invalid) {
-      <mat-error>Enter a value between 1 and 30</mat-error>
-    }
-  </mat-form-field>
-
-  @if (form.valid) {
-  <div class="capacity-summary">
-    <mat-icon>info</mat-icon>
-    Effective train capacity: <strong>{{ trainCapacity }} people</strong>
+<div class="dialog">
+  <div class="dialog-head">
+    <div>
+      <div class="dialog-tag">CONFIG · 03</div>
+      <div class="dialog-title">Simulation parameters</div>
+    </div>
+    <button class="dialog-close" (click)="cancel()">
+      <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+        <path d="M3 3l6 6M9 3l-6 6"/>
+      </svg>
+    </button>
   </div>
-  }
 
-</mat-dialog-content>
+  <div class="dialog-body" [formGroup]="form">
 
-<mat-dialog-actions align="end">
-  <button mat-button (click)="cancel()">Cancel</button>
-  <button mat-flat-button color="primary" [disabled]="form.invalid" (click)="apply()">Apply</button>
-</mat-dialog-actions>
+    <div class="field">
+      <div class="field-head">
+        <label class="field-label" for="wagonCap">WAGON CAPACITY</label>
+        <span class="field-range">1 – 500 PAX</span>
+      </div>
+      <div class="field-input">
+        <input type="range" id="wagonCap" min="1" max="500" step="5"
+               formControlName="wagonCapacity">
+        <input type="number" min="1" max="500" step="5"
+               formControlName="wagonCapacity">
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="field-head">
+        <label class="field-label" for="wagons">WAGONS PER TRAIN</label>
+        <span class="field-range">1 – 20 UNITS</span>
+      </div>
+      <div class="field-input">
+        <input type="range" id="wagons" min="1" max="20" step="1"
+               formControlName="wagonsPerTrain">
+        <input type="number" min="1" max="20" step="1"
+               formControlName="wagonsPerTrain">
+      </div>
+    </div>
+
+    <div class="field">
+      <div class="field-head">
+        <label class="field-label" for="trains">TRAINS / QUARTER HOUR</label>
+        <span class="field-range">1 – 30 PER LINE</span>
+      </div>
+      <div class="field-input">
+        <input type="range" id="trains" min="1" max="30" step="1"
+               formControlName="trainsPerQuarterHour">
+        <input type="number" min="1" max="30" step="1"
+               formControlName="trainsPerQuarterHour">
+      </div>
+    </div>
+
+    <div class="summary">
+      <div>
+        <div class="k">EFFECTIVE TRAIN CAPACITY</div>
+        <div class="summary-formula">{{ form.value.wagonCapacity }} × {{ form.value.wagonsPerTrain }}</div>
+      </div>
+      <div class="v">{{ trainCapacity }}<span class="unit">PAX</span></div>
+    </div>
+
+  </div>
+
+  <div class="dialog-foot">
+    <button class="btn" (click)="cancel()">CANCEL</button>
+    <button class="btn btn-primary" [disabled]="form.invalid" (click)="apply()">APPLY</button>
+  </div>
+</div>

--- a/metro/src/app/config-dialog/config-dialog.component.ts
+++ b/metro/src/app/config-dialog/config-dialog.component.ts
@@ -1,33 +1,22 @@
 import { Component } from '@angular/core';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatButtonModule } from '@angular/material/button';
-import { MatIconModule } from '@angular/material/icon';
+import { MatDialogRef } from '@angular/material/dialog';
 
 import { SimulationConfigService } from '../services/simulation-config.service';
 
 @Component({
   selector: 'app-config-dialog',
   standalone: true,
-  imports: [
-    ReactiveFormsModule,
-    MatDialogModule,
-    MatFormFieldModule,
-    MatInputModule,
-    MatButtonModule,
-    MatIconModule,
-  ],
+  imports: [ReactiveFormsModule],
   templateUrl: './config-dialog.component.html',
   styleUrls: ['./config-dialog.component.css'],
 })
 export class ConfigDialogComponent {
 
   readonly form = this.fb.group({
-    wagonCapacity:       [this.cfg.config.wagonCapacity,       [Validators.required, Validators.min(1), Validators.max(500)]],
-    wagonsPerTrain:      [this.cfg.config.wagonsPerTrain,      [Validators.required, Validators.min(1), Validators.max(20)]],
-    trainsPerQuarterHour:[this.cfg.config.trainsPerQuarterHour,[Validators.required, Validators.min(1), Validators.max(30)]],
+    wagonCapacity:        [this.cfg.config.wagonCapacity,        [Validators.required, Validators.min(1), Validators.max(500)]],
+    wagonsPerTrain:       [this.cfg.config.wagonsPerTrain,       [Validators.required, Validators.min(1), Validators.max(20)]],
+    trainsPerQuarterHour: [this.cfg.config.trainsPerQuarterHour, [Validators.required, Validators.min(1), Validators.max(30)]],
   });
 
   constructor(
@@ -37,9 +26,7 @@ export class ConfigDialogComponent {
   ) {}
 
   get trainCapacity(): number {
-    const cap = this.form.value.wagonCapacity ?? 0;
-    const wagons = this.form.value.wagonsPerTrain ?? 0;
-    return cap * wagons;
+    return (this.form.value.wagonCapacity ?? 0) * (this.form.value.wagonsPerTrain ?? 0);
   }
 
   apply(): void {

--- a/metro/src/app/header/header.component.css
+++ b/metro/src/app/header/header.component.css
@@ -1,71 +1,136 @@
 .topbar {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
-  justify-content: space-between;
-  height: 48px;
-  padding: 0 16px;
-  background: #161b22;
-  border-bottom: 1px solid #30363d;
-  flex-shrink: 0;
-  z-index: 100;
+  height: 44px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--line-2);
+  padding: 0 14px;
+  position: relative;
+  z-index: 30;
+  gap: 24px;
 }
 
-.topbar-left {
+.topbar::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; bottom: -1px;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, var(--amber-dim) 20%, var(--amber) 50%, var(--amber-dim) 80%, transparent);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+/* ── Brand ────────────────────────────────────────────── */
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.brand-logo {
+  width: 22px; height: 22px;
+  border: 1.5px solid var(--amber);
+  background: var(--bg-1);
+  position: relative;
+  display: grid;
+  place-items: center;
+  flex-shrink: 0;
+}
+.brand-logo::before, .brand-logo::after {
+  content: '';
+  position: absolute;
+  background: var(--amber);
+}
+.brand-logo::before { width: 60%; height: 1.5px; }
+.brand-logo::after  { width: 1.5px; height: 60%; }
+
+.brand-title {
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  color: var(--t-1);
+}
+.brand-sub {
+  font-size: 9px;
+  letter-spacing: 0.32em;
+  color: var(--t-3);
+  margin-top: 1px;
+}
+.brand-rev {
+  font-size: 9px;
+  color: var(--amber);
+  letter-spacing: 0.16em;
+  padding-left: 12px;
+  margin-left: 8px;
+  border-left: 1px solid var(--line-2);
+  text-transform: uppercase;
+}
+
+/* ── Center meta ──────────────────────────────────────── */
+.topbar-center {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 18px;
+  font-size: 10px;
+  color: var(--t-3);
+  letter-spacing: 0.18em;
+}
+.topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.topbar-meta .v {
+  color: var(--t-1);
+  font-weight: 500;
+  letter-spacing: 0.06em;
+}
+
+/* ── Right ────────────────────────────────────────────── */
+.topbar-right {
   display: flex;
   align-items: center;
   gap: 8px;
 }
 
-.topbar-icon {
-  font-size: 20px;
-  color: #58a6ff;
-}
-
-.topbar-title {
-  font-size: 15px;
-  font-weight: 600;
-  color: #e6edf3;
-  letter-spacing: 0.01em;
-}
-
-.topbar-right {
+/* connection chip */
+.conn {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--line-2);
+  background: var(--bg-1);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  color: var(--t-2);
+  height: 28px;
 }
-
-.status-dot {
-  width: 8px;
-  height: 8px;
+.conn-dot {
+  width: 7px; height: 7px;
   border-radius: 50%;
-  background: #6e7681;
-  transition: background 0.3s;
+  background: var(--t-4);
 }
+.conn.connected    .conn-dot { background: var(--ok);   box-shadow: 0 0 8px var(--ok); }
+.conn.reconnecting .conn-dot { background: var(--warn); box-shadow: 0 0 8px var(--warn); animation: pulse 1.2s infinite; }
+.conn.disconnected .conn-dot { background: var(--crit); }
 
-.status-dot.connected    { background: #3fb950; box-shadow: 0 0 6px #3fb95066; }
-.status-dot.reconnecting { background: #d29922; box-shadow: 0 0 6px #d2992266; }
-.status-dot.disconnected { background: #f85149; }
-
+/* icon button */
 .icon-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 6px;
-  color: #8b949e;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s, background 0.15s;
+  display: grid;
+  place-items: center;
+  width: 28px; height: 28px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--t-2);
+  transition: color .12s, border-color .12s, background .12s;
 }
-
 .icon-btn:hover {
-  color: #e6edf3;
-  border-color: #30363d;
-  background: #21262d;
+  color: var(--amber);
+  border-color: var(--amber-dim);
+  background: var(--bg-3);
 }
-
-.icon-btn .material-icons {
-  font-size: 18px;
-}
+.icon-btn svg { width: 14px; height: 14px; }

--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -1,14 +1,32 @@
 <header class="topbar">
-  <div class="topbar-left">
-    <span class="material-icons topbar-icon">train</span>
-    <span class="topbar-title">Metro Simu</span>
+  <div class="brand">
+    <div class="brand-logo"></div>
+    <div>
+      <div class="brand-title">METRO · OPS</div>
+      <div class="brand-sub">MADRID NETWORK SIMULATOR</div>
+    </div>
+    <span class="brand-rev">REV 4·26</span>
   </div>
+
+  <div class="topbar-center">
+    <div class="topbar-meta"><span>NODE</span><span class="v">MAD-001</span></div>
+    <div class="topbar-meta"><span>SESSION</span><span class="v">{{ sessionId }}</span></div>
+    <div class="topbar-meta"><span>TICK</span><span class="v">{{ state.paused ? 'HOLD' : 'LIVE' }}</span></div>
+    <div class="topbar-meta"><span>×</span><span class="v">{{ state.timeMultiplier.toFixed(2) }}</span></div>
+  </div>
+
   <div class="topbar-right">
     @if (status$ | async; as s) {
-      <span class="status-dot" [class]="s" [title]="s"></span>
+      <div class="conn" [class]="s">
+        <span class="conn-dot"></span>
+        <span>{{ s.toUpperCase() }}</span>
+      </div>
     }
-    <button class="icon-btn" (click)="openConfig()" title="Simulation settings">
-      <span class="material-icons">settings</span>
+    <button class="icon-btn" (click)="openConfig()" title="Configuration">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4">
+        <circle cx="8" cy="8" r="2.2"/>
+        <path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M3.4 12.6l1.4-1.4M11.2 4.8l1.4-1.4" stroke-linecap="round"/>
+      </svg>
     </button>
   </div>
 </header>

--- a/metro/src/app/header/header.component.spec.ts
+++ b/metro/src/app/header/header.component.spec.ts
@@ -4,6 +4,7 @@ import { BehaviorSubject } from 'rxjs';
 
 import { HeaderComponent } from './header.component';
 import { WebSocketService } from '../services/websocket.service';
+import { SimulationStateService } from '../services/simulation-state.service';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -17,7 +18,10 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HeaderComponent],
-      providers: [{ provide: WebSocketService, useValue: mockWs }],
+      providers: [
+        { provide: WebSocketService, useValue: mockWs },
+        SimulationStateService,
+      ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();
 
@@ -30,19 +34,14 @@ describe('HeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('statusIcon should return wifi for connected', () => {
-    expect(component.statusIcon('connected')).toBe('wifi');
+  it('should generate a session id string starting with A', () => {
+    expect(component.sessionId).toMatch(/^A\d+$/);
   });
 
-  it('statusIcon should return wifi_find for reconnecting', () => {
-    expect(component.statusIcon('reconnecting')).toBe('wifi_find');
-  });
-
-  it('statusIcon should return wifi_off for disconnected', () => {
-    expect(component.statusIcon('disconnected')).toBe('wifi_off');
-  });
-
-  it('statusColor should return green for connected', () => {
-    expect(component.statusColor('connected')).toBe('#3fb950');
+  it('should expose connection status observable', (done) => {
+    component.status$.subscribe(status => {
+      expect(status).toBe('disconnected');
+      done();
+    });
   });
 });

--- a/metro/src/app/header/header.component.ts
+++ b/metro/src/app/header/header.component.ts
@@ -2,7 +2,8 @@ import { Component } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { MatDialog } from '@angular/material/dialog';
 
-import { WebSocketService, ConnectionStatus } from '../services/websocket.service';
+import { WebSocketService } from '../services/websocket.service';
+import { SimulationStateService } from '../services/simulation-state.service';
 import { ConfigDialogComponent } from '../config-dialog/config-dialog.component';
 
 @Component({
@@ -14,21 +15,15 @@ import { ConfigDialogComponent } from '../config-dialog/config-dialog.component'
 })
 export class HeaderComponent {
   readonly status$ = this.ws.connectionStatus$;
+  readonly sessionId = 'A' + Math.floor((Date.now() / 1000) % 9999).toString().padStart(4, '0');
 
   constructor(
     private readonly ws: WebSocketService,
     private readonly dialog: MatDialog,
+    readonly state: SimulationStateService,
   ) {}
 
   openConfig(): void {
-    this.dialog.open(ConfigDialogComponent, { width: '420px' });
-  }
-
-  statusIcon(s: ConnectionStatus): string {
-    return s === 'connected' ? 'wifi' : s === 'reconnecting' ? 'wifi_find' : 'wifi_off';
-  }
-
-  statusColor(s: ConnectionStatus): string {
-    return s === 'connected' ? '#3fb950' : s === 'reconnecting' ? '#d29922' : '#f85149';
+    this.dialog.open(ConfigDialogComponent, { width: '460px' });
   }
 }

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -1,4 +1,4 @@
-/* ── Host fills the flex parent ──────────────────────────── */
+/* ── Host ─────────────────────────────────────────────────── */
 :host {
   display: block;
   flex: 1;
@@ -6,12 +6,11 @@
   position: relative;
 }
 
-/* ── Root layout ─────────────────────────────────────────── */
+/* ── Map root ─────────────────────────────────────────────── */
 .map-root {
   position: absolute;
   inset: 0;
   overflow: hidden;
-  background: #0d1117;
 }
 
 /* ── Canvas stack ─────────────────────────────────────────── */
@@ -20,438 +19,534 @@
   inset: 0;
   overflow: hidden;
   cursor: grab;
-  display: flex;
-  align-items: flex-start;
-  justify-content: flex-start;
 }
+.canvas-container:active { cursor: grabbing; }
+.canvas-layer { position: absolute; top: 0; left: 0; display: block; }
 
-.canvas-container:active {
-  cursor: grabbing;
-}
-
-.canvas-layer {
+/* ── Corner brackets ──────────────────────────────────────── */
+.corners {
   position: absolute;
-  top: 0;
-  left: 0;
-  display: block;
+  inset: 8px;
+  pointer-events: none;
+  z-index: 5;
 }
+.corner {
+  position: absolute;
+  width: 14px; height: 14px;
+  border: 1px solid var(--line-3);
+}
+.corner.tl { top: 0; left: 0; border-right: none; border-bottom: none; }
+.corner.tr { top: 0; right: 0; border-left: none; border-bottom: none; }
+.corner.bl { bottom: 0; left: 0; border-right: none; border-top: none; }
+.corner.br { bottom: 0; right: 0; border-left: none; border-top: none; }
 
-/* ── Floating stats panel ─────────────────────────────────── */
+/* ── Scope crosshair ──────────────────────────────────────── */
+.scope {
+  position: absolute;
+  left: 50%; top: 50%;
+  transform: translate(-50%, -50%);
+  width: 24px; height: 24px;
+  pointer-events: none;
+  z-index: 4;
+  opacity: 0.25;
+}
+.scope::before, .scope::after {
+  content: '';
+  position: absolute;
+  background: var(--amber);
+}
+.scope::before { left: 50%; top: 0; bottom: 0; width: 1px; transform: translateX(-0.5px); }
+.scope::after  { top: 50%; left: 0; right: 0; height: 1px; transform: translateY(-0.5px); }
+
+/* ── Panels ───────────────────────────────────────────────── */
 .panel {
   position: absolute;
   top: 12px;
-  width: 220px;
-  background: rgba(13, 17, 23, 0.92);
-  border: 1px solid #30363d;
-  border-radius: 10px;
-  backdrop-filter: blur(8px);
+  width: 280px;
+  background: rgba(12, 14, 17, 0.92);
+  border: 1px solid var(--line-2);
+  backdrop-filter: blur(12px) saturate(140%);
   z-index: 20;
-  transition: width 0.2s ease;
-  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  max-height: calc(100vh - 100px);
 }
-
-.panel-left  { left:  12px; }
+.panel-left  { left: 12px; }
 .panel-right { right: 12px; }
 
-.panel--collapsed {
-  width: 36px;
+.panel--collapsed { width: 32px; }
+.panel--collapsed .panel-body { display: none; }
+
+.panel-head {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  height: 30px;
+  padding: 0 0 0 12px;
+  border-bottom: 1px solid var(--line-2);
+  background: var(--bg-2);
+  gap: 8px;
+  flex-shrink: 0;
+}
+/* right panel: toggle is first column */
+.panel-head:has(.panel-toggle--left) {
+  grid-template-columns: auto auto 1fr auto;
+  padding: 0;
 }
 
-/* Toggle button */
+.panel-head-title {
+  font-size: 9px;
+  letter-spacing: 0.32em;
+  color: var(--amber);
+  font-weight: 600;
+}
+.panel-head-id {
+  font-size: 9px;
+  color: var(--t-4);
+  letter-spacing: 0.16em;
+  text-align: right;
+  padding-right: 8px;
+}
+
 .panel-toggle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  height: 36px;
   background: none;
   border: none;
-  border-bottom: 1px solid #30363d;
-  color: #8b949e;
-  cursor: pointer;
-  padding: 0;
-  transition: color 0.15s, background 0.15s;
-}
-
-.panel-toggle:hover {
-  color: #e6edf3;
-  background: #161b22;
-}
-
-.panel-toggle .material-icons {
-  font-size: 16px;
-}
-
-/* Panel body */
-.panel-body {
-  padding: 10px 12px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-  overflow: hidden;
-}
-
-.panel-section {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.panel-label {
-  font-size: 9px;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  color: #6e7681;
-  text-transform: uppercase;
-  margin-bottom: 2px;
-}
-
-.panel-clock {
-  font-size: 22px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  color: #58a6ff;
-  line-height: 1.1;
-}
-
-.panel-sub {
-  font-size: 11px;
-  color: #6e7681;
-}
-
-.panel-divider {
-  height: 1px;
-  background: #21262d;
-  margin: 8px 0;
-}
-
-/* Stat rows */
-.stat-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 2px 0;
-}
-
-.stat-name {
-  font-size: 11px;
-  color: #8b949e;
-}
-
-.stat-val {
-  font-size: 11px;
-  font-weight: 600;
-  color: #e6edf3;
-}
-
-.stat-row.capacity .stat-val {
-  color: #3fb950;
-}
-
-/* By-line rows */
-.line-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 2px 0;
-}
-
-.line-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
+  border-left: 1px solid var(--line-2);
+  color: var(--t-3);
+  width: 30px; height: 30px;
+  display: grid;
+  place-items: center;
   flex-shrink: 0;
 }
-
-.line-num {
-  font-size: 10px;
-  font-weight: 600;
-  color: #e6edf3;
-  width: 26px;
-  text-align: right;
-  flex-shrink: 0;
+.panel-toggle--left {
+  border-left: none;
+  border-right: 1px solid var(--line-2);
 }
-
-.line-bar-bg {
-  flex: 1;
-  height: 4px;
-  background: #21262d;
-  border-radius: 2px;
-  overflow: hidden;
-}
-
-.line-bar-fill {
-  height: 100%;
-  border-radius: 2px;
-  min-width: 2px;
-  transition: width 0.4s ease;
-}
-
-.line-count {
-  font-size: 10px;
-  color: #8b949e;
-  width: 34px;
-  text-align: right;
-  flex-shrink: 0;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-}
-
-/* ── Inline config rows ──────────────────────────────────── */
-.cfg-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 2px 0;
-  gap: 6px;
-}
-
-.cfg-label {
-  font-size: 11px;
-  color: #8b949e;
-  flex: 1;
-  white-space: nowrap;
-}
-
-/* ── Stepper control ─────────────────────────────────────── */
-.stepper {
-  display: flex;
-  align-items: center;
-  gap: 0;
-  border: 1px solid #30363d;
-  border-radius: 4px;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.stepper-btn {
-  width: 24px;
-  height: 24px;
-  background: #161b22;
+.panel-toggle--solo {
   border: none;
-  color: #8b949e;
-  font-size: 14px;
-  line-height: 1;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  border-bottom: 1px solid var(--line-2);
+  width: 100%;
+  height: 32px;
+}
+.panel-toggle:hover, .panel-toggle--left:hover, .panel-toggle--solo:hover {
+  color: var(--amber);
+  background: var(--bg-3);
+}
+.panel-toggle svg, .panel-toggle--solo svg { width: 12px; height: 12px; }
+
+.panel-body {
   padding: 0;
-  transition: color 0.12s, background 0.12s;
-  flex-shrink: 0;
+  overflow-y: auto;
+  flex: 1;
 }
 
-.stepper-btn:hover {
-  color: #e6edf3;
-  background: #21262d;
+/* ── Sections ─────────────────────────────────────────────── */
+.section {
+  border-bottom: 1px solid var(--line-1);
+  padding: 10px 14px 12px;
 }
+.section:last-child { border-bottom: none; }
 
-.stepper-val {
-  min-width: 36px;
-  text-align: center;
-  font-size: 11px;
-  font-weight: 600;
-  color: #e6edf3;
-  background: #0d1117;
-  padding: 0 4px;
-  height: 24px;
+.section-head {
   display: flex;
   align-items: center;
-  justify-content: center;
-  border-left: 1px solid #30363d;
-  border-right: 1px solid #30363d;
+  justify-content: space-between;
+  margin-bottom: 8px;
 }
-
-/* ── Time input ──────────────────────────────────────────── */
-.time-input {
-  background: #161b22;
-  border: 1px solid #30363d;
-  border-radius: 4px;
-  color: #e6edf3;
-  font-size: 11px;
+.section-title {
+  font-size: 9px;
+  letter-spacing: 0.28em;
+  color: var(--t-3);
   font-weight: 600;
-  padding: 3px 5px;
-  width: 80px;
-  text-align: center;
-  flex-shrink: 0;
-  color-scheme: dark;
+}
+.section-meta {
+  font-size: 9px;
+  letter-spacing: 0.16em;
+  color: var(--t-4);
 }
 
-.time-input:focus {
-  outline: none;
-  border-color: #58a6ff;
+/* ── Clock ────────────────────────────────────────────────── */
+.clock {
+  font-family: var(--sans);
+  font-size: 36px;
+  font-weight: 500;
+  color: var(--amber);
+  letter-spacing: 0.04em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  text-shadow: 0 0 18px rgba(245, 180, 84, 0.18);
 }
+.tape {
+  position: relative;
+  height: 14px;
+  margin: 8px 0 4px;
+  border-top: 1px solid var(--line-2);
+  border-bottom: 1px solid var(--line-2);
+  background: repeating-linear-gradient(
+    90deg,
+    transparent 0, transparent 19px,
+    var(--line-2) 19px, var(--line-2) 20px
+  );
+  overflow: hidden;
+}
+.tape::after {
+  content: '';
+  position: absolute;
+  top: 0; bottom: 0;
+  width: 2px;
+  background: var(--amber);
+  box-shadow: 0 0 8px var(--amber);
+  left: var(--progress, 0%);
+}
+.clock-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: var(--t-3);
+  letter-spacing: 0.12em;
+}
+.clock-meta .v { color: var(--t-1); }
 
-/* ── Simulation controls row (play + time + reset) ──────── */
-.sim-controls {
+/* ── KPI (right panel population) ────────────────────────── */
+.kpi { display: flex; flex-direction: column; gap: 2px; }
+.kpi-val {
+  font-family: var(--sans);
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--t-1);
+}
+.kpi-val.amber { color: var(--amber); }
+.kpi-val .unit {
+  font-size: 11px;
+  color: var(--t-3);
+  font-weight: 400;
+  letter-spacing: 0.12em;
+  margin-left: 6px;
+}
+.kpi-sub {
+  display: flex;
+  gap: 10px;
+  font-size: 10px;
+  color: var(--t-3);
+  letter-spacing: 0.08em;
+  margin-top: 2px;
+}
+.kpi-sub-v { color: var(--t-1); }
+
+.sparkline-wrap { margin-top: 8px; }
+
+/* ── Stat rows ────────────────────────────────────────────── */
+.stat-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: baseline;
+  padding: 4px 0;
+  gap: 12px;
+}
+.stat-row + .stat-row { border-top: 1px dashed var(--line-1); }
+
+.row-name {
+  font-size: 10px;
+  color: var(--t-2);
+  letter-spacing: 0.08em;
   display: flex;
   align-items: center;
   gap: 6px;
-  margin-top: 4px;
 }
-
-.sim-controls .time-input {
-  flex: 1;
-  margin-top: 0;
-}
-
-/* ── Play/Pause button ───────────────────────────────────── */
-.play-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
+.row-name::before {
+  content: '';
+  width: 4px; height: 4px;
+  background: var(--t-4);
   flex-shrink: 0;
-  background: #161b22;
-  border: 1px solid #30363d;
-  border-radius: 6px;
-  color: #3fb950;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
 }
-
-.play-btn:hover {
-  color: #58a6ff;
-  border-color: #58a6ff;
+.row-val {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--t-1);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.04em;
 }
+.row-val.ok   { color: var(--ok); }
+.row-val.warn { color: var(--warn); }
+.row-val.crit { color: var(--crit); }
+.row-val .unit { color: var(--t-3); margin-left: 4px; font-size: 10px; }
 
-.play-btn .material-icons {
-  font-size: 16px;
-}
-
-/* ── Reset button ────────────────────────────────────────── */
-.reset-btn {
-  display: flex;
-  align-items: center;
-  gap: 5px;
-  margin-top: 4px;
-  padding: 5px 8px;
-  background: #161b22;
-  border: 1px solid #30363d;
-  border-radius: 6px;
-  color: #8b949e;
-  font-size: 11px;
-  cursor: pointer;
-  transition: color 0.15s, border-color 0.15s;
-  width: 100%;
-}
-
-.reset-btn.icon-only {
-  width: 30px;
-  height: 30px;
-  flex-shrink: 0;
-  margin-top: 0;
-  padding: 0;
-  justify-content: center;
-}
-
-.reset-btn:hover {
-  color: #f85149;
-  border-color: #f85149;
-}
-
-.reset-btn .material-icons {
-  font-size: 13px;
-}
-
-/* ── CPU load indicator ──────────────────────────────────── */
-.load-indicator {
-  display: flex;
+/* ── Stepper ──────────────────────────────────────────────── */
+.cfg-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 8px;
-  margin-bottom: 6px;
+  padding: 5px 0;
 }
-
-.load-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  flex-shrink: 0;
-  transition: background 0.4s;
+.cfg-label {
+  font-size: 10px;
+  color: var(--t-2);
+  letter-spacing: 0.06em;
 }
-
-.load-ok   { background: #3fb950; }
-.load-warn { background: #d29922; }
-.load-over { background: #f85149; }
-
-.load-val {
-  font-size: 12px;
-  font-weight: 600;
-  color: #e6edf3;
+.stepper {
+  display: grid;
+  grid-template-columns: 22px 50px 22px;
+  border: 1px solid var(--line-2);
+  height: 24px;
+  background: var(--bg-1);
 }
-
-/* ── Zoom indicator (dev only) ───────────────────────────── */
-.zoom-indicator {
-  position: absolute;
-  bottom: 148px;
-  right: 12px;
-  background: rgba(13, 17, 23, 0.92);
-  border: 1px solid #30363d;
-  border-radius: 6px;
-  padding: 4px 8px;
-  font-size: 11px;
-  font-weight: 600;
-  color: #f0b429;
-  letter-spacing: 0.05em;
-  z-index: 20;
-  pointer-events: none;
-}
-
-/* ── Zoom bar ─────────────────────────────────────────────── */
-.zoom-bar {
-  position: absolute;
-  bottom: 20px;
-  right: 12px;
-  display: flex;
-  flex-direction: column;
-  background: rgba(13, 17, 23, 0.92);
-  border: 1px solid #30363d;
-  border-radius: 8px;
-  backdrop-filter: blur(8px);
-  overflow: hidden;
-  z-index: 20;
-}
-
-.zoom-btn {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
+.stepper-btn {
   background: none;
   border: none;
-  color: #8b949e;
-  cursor: pointer;
-  padding: 0;
-  transition: color 0.15s, background 0.15s;
+  color: var(--t-3);
+  display: grid;
+  place-items: center;
+  font-size: 12px;
+  transition: color .12s, background .12s;
+}
+.stepper-btn:hover { color: var(--amber); background: var(--bg-3); }
+.stepper-val {
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  color: var(--t-1);
+  font-weight: 500;
+  border-left: 1px solid var(--line-2);
+  border-right: 1px solid var(--line-2);
+  letter-spacing: 0.06em;
+  font-variant-numeric: tabular-nums;
 }
 
-.zoom-btn:hover {
-  color: #e6edf3;
-  background: #161b22;
+/* ── Speed presets ────────────────────────────────────────── */
+.speed-row {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.speed-btn {
+  flex: 1;
+  min-width: 32px;
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--t-3);
+  height: 24px;
+  font-size: 10px;
+  font-family: var(--mono);
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.speed-btn:hover { color: var(--t-1); border-color: var(--line-3); }
+.speed-btn.active {
+  color: var(--amber);
+  border-color: var(--amber-dim);
+  background: rgba(245, 180, 84, 0.06);
 }
 
-.zoom-btn .material-icons {
+/* ── Sim controls ─────────────────────────────────────────── */
+.sim-controls {
+  display: grid;
+  grid-template-columns: 36px 1fr 28px;
+  gap: 6px;
+  align-items: center;
+}
+.btn-play {
+  background: var(--bg-1);
+  border: 1px solid var(--amber-dim);
+  color: var(--amber);
+  height: 32px;
+  display: grid;
+  place-items: center;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.btn-play:hover { background: var(--amber); color: var(--bg-0); }
+.btn-play.paused { color: var(--ok); border-color: var(--ok); }
+.btn-play.paused:hover { background: var(--ok); color: var(--bg-0); }
+.btn-play svg { width: 12px; height: 12px; }
+
+.time-input {
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--t-1);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  height: 32px;
+  padding: 0 10px;
+  text-align: center;
+  font-weight: 500;
+  color-scheme: dark;
+  font-variant-numeric: tabular-nums;
+  width: 100%;
+}
+.time-input:focus { outline: none; border-color: var(--amber-dim); }
+
+.btn-reset {
+  background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  color: var(--t-3);
+  width: 28px; height: 32px;
+  display: grid;
+  place-items: center;
+  transition: color .12s, border-color .12s;
+}
+.btn-reset:hover { color: var(--crit); border-color: var(--crit); }
+.btn-reset svg { width: 12px; height: 12px; }
+
+/* ── Load gauge ───────────────────────────────────────────── */
+.gauge {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+.gauge-bars {
+  flex: 1;
+  display: flex;
+  gap: 2px;
+  height: 16px;
+}
+.gauge-bar {
+  flex: 1;
+  background: var(--line-1);
+  transition: background .2s;
+}
+.gauge-bar.on   { background: var(--ok); }
+.gauge-bar.warn { background: var(--warn); }
+.gauge-bar.over { background: var(--crit); }
+
+.gauge-val {
+  font-family: var(--sans);
   font-size: 18px;
+  color: var(--t-1);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  width: 52px;
+  text-align: right;
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+}
+.gauge-val.warn { color: var(--warn); }
+.gauge-val.crit { color: var(--crit); }
+.gauge-pct { font-size: 10px; color: var(--t-3); }
+
+/* ── Line rows (right panel) ──────────────────────────────── */
+.line-row {
+  display: grid;
+  grid-template-columns: 18px 1fr 46px;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 0;
+}
+.line-chip {
+  width: 18px; height: 16px;
+  display: grid;
+  place-items: center;
+  font-size: 8px;
+  font-weight: 700;
+  color: white;
+  font-family: var(--sans);
+  border-radius: 2px;
+  flex-shrink: 0;
+  letter-spacing: 0;
+}
+.line-bar-bg {
+  position: relative;
+  height: 6px;
+  background: var(--line-1);
+  overflow: hidden;
+}
+.line-bar-fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  transition: width .4s ease;
+  min-width: 1px;
+}
+.line-count {
+  font-size: 11px;
+  color: var(--t-1);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  letter-spacing: 0.04em;
 }
 
-.zoom-sep {
-  height: 1px;
-  background: #30363d;
+/* ── Telemetry strip ──────────────────────────────────────── */
+.telemetry {
+  position: absolute;
+  bottom: 14px;
+  left: 14px;
+  right: 56px;
+  height: 30px;
+  background: rgba(12, 14, 17, 0.88);
+  border: 1px solid var(--line-2);
+  backdrop-filter: blur(8px);
+  display: grid;
+  grid-template-columns: auto 1fr auto auto auto auto;
+  align-items: center;
+  padding: 0 14px;
+  gap: 16px;
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--t-2);
+  z-index: 18;
+  pointer-events: none;
 }
-
-/* ── Responsive: shrink panel on small screens ────────────── */
-@media (max-width: 600px) {
-  .panel {
-    width: 180px;
-    top: 8px;
-    right: 8px;
-  }
-
-  .zoom-bar {
-    bottom: 12px;
-    right: 8px;
-  }
+.telemetry-tag { color: var(--amber); font-weight: 600; }
+.telemetry-track {
+  position: relative;
+  height: 2px;
+  background: var(--line-1);
+  overflow: hidden;
 }
+.telemetry-track::before {
+  content: '';
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--p, 0%);
+  background: var(--amber);
+}
+.telemetry-stat .k { color: var(--t-3); }
+.telemetry-stat .v { color: var(--t-1); margin-left: 5px; font-variant-numeric: tabular-nums; }
+
+/* ── Zoom controls ────────────────────────────────────────── */
+.zoom-readout {
+  position: absolute;
+  bottom: 56px;
+  right: 14px;
+  background: rgba(12, 14, 17, 0.92);
+  border: 1px solid var(--line-2);
+  border-bottom: none;
+  font-size: 10px;
+  color: var(--amber);
+  text-align: center;
+  padding: 4px 0;
+  letter-spacing: 0.08em;
+  font-variant-numeric: tabular-nums;
+  width: 40px;
+  z-index: 20;
+}
+.zoom-bar {
+  position: absolute;
+  bottom: 14px;
+  right: 14px;
+  display: flex;
+  flex-direction: column;
+  background: rgba(12, 14, 17, 0.92);
+  border: 1px solid var(--line-2);
+  backdrop-filter: blur(8px);
+  z-index: 20;
+  width: 40px;
+}
+.zoom-btn {
+  width: 40px; height: 32px;
+  background: none;
+  border: none;
+  color: var(--t-2);
+  display: grid;
+  place-items: center;
+  transition: color .12s, background .12s;
+}
+.zoom-btn + .zoom-btn { border-top: 1px solid var(--line-2); }
+.zoom-btn:hover { color: var(--amber); background: var(--bg-3); }
+.zoom-btn svg { width: 12px; height: 12px; }

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -7,177 +7,267 @@
     <canvas #canvas_trains   class="canvas-layer"></canvas>
   </div>
 
-  <!-- Left panel: configurable parameters -->
+  <!-- Corner brackets -->
+  <div class="corners" aria-hidden="true">
+    <div class="corner tl"></div>
+    <div class="corner tr"></div>
+    <div class="corner bl"></div>
+    <div class="corner br"></div>
+  </div>
+
+  <!-- Scope crosshair -->
+  <div class="scope" aria-hidden="true"></div>
+
+  <!-- ── Left panel: CONTROL · INPUT ── -->
   <aside class="panel panel-left" [class.panel--collapsed]="leftCollapsed">
-    <button class="panel-toggle" (click)="leftCollapsed = !leftCollapsed"
-            [title]="leftCollapsed ? 'Expand' : 'Collapse'">
-      <span class="material-icons">{{ leftCollapsed ? 'chevron_right' : 'chevron_left' }}</span>
-    </button>
-
     @if (!leftCollapsed) {
-      <div class="panel-body">
-
-        <div class="panel-section">
-          <span class="panel-label">CLOCK</span>
-          <span class="panel-clock">{{ displayClock() }}</span>
-          <span class="panel-sub">×{{ state.timeMultiplier }} speed</span>
-        </div>
-
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">TRAIN CONFIG</span>
-          <div class="cfg-row">
-            <label class="cfg-label">Wagon cap.</label>
-            <div class="stepper">
-              <button class="stepper-btn" (click)="stepConfig('wagonCapacity', -5)">−</button>
-              <span class="stepper-val">{{ cfg.config.wagonCapacity }}</span>
-              <button class="stepper-btn" (click)="stepConfig('wagonCapacity', 5)">+</button>
-            </div>
-          </div>
-          <div class="cfg-row">
-            <label class="cfg-label">Wagons/train</label>
-            <div class="stepper">
-              <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', -1)">−</button>
-              <span class="stepper-val">{{ cfg.config.wagonsPerTrain }}</span>
-              <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', 1)">+</button>
-            </div>
-          </div>
-          <div class="stat-row capacity">
-            <span class="stat-name">Capacity</span>
-            <span class="stat-val">{{ cfg.trainCapacity }} pax</span>
-          </div>
-        </div>
-
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">SPEED</span>
-          <div class="cfg-row">
-            <label class="cfg-label">Sim speed</label>
-            <div class="stepper">
-              <button class="stepper-btn" (click)="speedDown()">−</button>
-              <span class="stepper-val">×{{ localSpeed }}</span>
-              <button class="stepper-btn" (click)="speedUp()">+</button>
-            </div>
-          </div>
-        </div>
-
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">SIMULATION</span>
-          <div class="sim-controls">
-            <button class="play-btn" (click)="playPause()" [title]="state.paused ? 'Resume' : 'Pause'">
-              <span class="material-icons">{{ state.paused ? 'play_arrow' : 'pause' }}</span>
-            </button>
-            <input class="time-input" type="time"
-                   [value]="resetTime"
-                   (change)="resetTime = $any($event.target).value">
-            <button class="reset-btn icon-only" (click)="resetSimulation()" title="Reset">
-              <span class="material-icons">restart_alt</span>
-            </button>
-          </div>
-        </div>
-
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">CPU LOAD</span>
-          <div class="load-indicator">
-            <div class="load-dot" [class.load-ok]="state.simLoad <= 0.7"
-                                  [class.load-warn]="state.simLoad > 0.7 && state.simLoad <= 1.0"
-                                  [class.load-over]="state.simLoad > 1.0"></div>
-            <span class="load-val">{{ (state.simLoad * 100).toFixed(0) }}%</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Events/tick</span>
-            <span class="stat-val">{{ state.eventsPerTick }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Queue</span>
-            <span class="stat-val">{{ state.queueSize }}</span>
-          </div>
-        </div>
-
+      <div class="panel-head">
+        <span class="panel-head-title">CONTROL · INPUT</span>
+        <span class="panel-head-id">CH·01</span>
+        <button class="panel-toggle" (click)="leftCollapsed = true">
+          <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="7.5,2.5 4,6 7.5,9.5"/>
+          </svg>
+        </button>
       </div>
+    } @else {
+      <button class="panel-toggle panel-toggle--solo" (click)="leftCollapsed = false">
+        <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="4.5,2.5 8,6 4.5,9.5"/>
+        </svg>
+      </button>
     }
-  </aside>
 
-  <!-- Right panel: simulation results -->
-  <aside class="panel panel-right" [class.panel--collapsed]="rightCollapsed">
-    <button class="panel-toggle" (click)="rightCollapsed = !rightCollapsed"
-            [title]="rightCollapsed ? 'Expand' : 'Collapse'">
-      <span class="material-icons">{{ rightCollapsed ? 'chevron_left' : 'chevron_right' }}</span>
-    </button>
+    <div class="panel-body">
 
-    @if (!rightCollapsed) {
-      <div class="panel-body">
+      <!-- SIM CLOCK -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">SIM · CLOCK</span>
+          <span class="section-meta">UTC</span>
+        </div>
+        <div class="clock">{{ displayClock() }}</div>
+        <div class="tape" [style.--progress]="(dayProgress * 100).toFixed(2) + '%'"></div>
+        <div class="clock-meta">
+          <span>×{{ localSpeed }} SPEED</span>
+          <span>DAY <span class="v">{{ (dayProgress * 100).toFixed(1) }}%</span></span>
+        </div>
+      </div>
 
-        <div class="panel-section">
-          <span class="panel-label">PEOPLE</span>
-          <div class="stat-row">
-            <span class="stat-name">Simulation</span>
-            <span class="stat-val">{{ state.simulationPeople }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">In metro</span>
-            <span class="stat-val">{{ state.metroPeople }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">In trains</span>
-            <span class="stat-val">{{ state.trainsPeople }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Platforms</span>
-            <span class="stat-val">{{ allPeople(state.platformsPeople) }}</span>
-          </div>
-          <div class="stat-row">
-            <span class="stat-name">Stations</span>
-            <span class="stat-val">{{ allPeople(state.stationsPeople) }}</span>
+      <!-- FLEET CONFIG -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">FLEET · CONFIG</span>
+          <span class="section-meta">ROLLING STOCK</span>
+        </div>
+        <div class="cfg-row">
+          <label class="cfg-label">WAGON CAP.</label>
+          <div class="stepper">
+            <button class="stepper-btn" (click)="stepConfig('wagonCapacity', -5)">−</button>
+            <div class="stepper-val">{{ cfg.config.wagonCapacity }}</div>
+            <button class="stepper-btn" (click)="stepConfig('wagonCapacity', 5)">+</button>
           </div>
         </div>
+        <div class="cfg-row">
+          <label class="cfg-label">WAGONS / TRAIN</label>
+          <div class="stepper">
+            <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', -1)">−</button>
+            <div class="stepper-val">{{ cfg.config.wagonsPerTrain }}</div>
+            <button class="stepper-btn" (click)="stepConfig('wagonsPerTrain', 1)">+</button>
+          </div>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">CAPACITY</span>
+          <span class="row-val ok">{{ cfg.trainCapacity }}<span class="unit">PAX</span></span>
+        </div>
+      </div>
 
-        <div class="panel-divider"></div>
-
-        <div class="panel-section">
-          <span class="panel-label">BY LINE</span>
-          @for (line of linePeople(); track line[0]) {
-            <div class="line-row">
-              <span class="line-dot" [style.background]="lineColors(line[0])"></span>
-              <span class="line-num">{{ line[0] }}</span>
-              <div class="line-bar-bg">
-                <div class="line-bar-fill"
-                     [style.width.%]="linePercent(line[1])"
-                     [style.background]="lineColors(line[0])">
-                </div>
-              </div>
-              <span class="line-count">{{ formatCount(line[1]) }}</span>
-            </div>
+      <!-- SPEED MULTIPLIER -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">TIME · MULTIPLIER</span>
+          <span class="section-meta">×{{ localSpeed }}</span>
+        </div>
+        <div class="speed-row">
+          @for (s of speedPresets; track s; let i = $index) {
+            <button class="speed-btn" [class.active]="i === speedIdx_" (click)="setSpeedIdx(i)">×{{ s }}</button>
           }
         </div>
-
       </div>
-    }
+
+      <!-- SIMULATION CONTROLS -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">SIMULATION</span>
+          <span class="section-meta">{{ state.paused ? 'PAUSED' : 'RUNNING' }}</span>
+        </div>
+        <div class="sim-controls">
+          <button class="btn-play" [class.paused]="state.paused" (click)="playPause()">
+            @if (state.paused) {
+              <svg viewBox="0 0 12 12" fill="currentColor"><path d="M3 2 L10 6 L3 10 Z"/></svg>
+            } @else {
+              <svg viewBox="0 0 12 12" fill="currentColor">
+                <rect x="3" y="2" width="2.5" height="8"/>
+                <rect x="6.5" y="2" width="2.5" height="8"/>
+              </svg>
+            }
+          </button>
+          <input class="time-input" type="time"
+                 [value]="resetTime"
+                 (change)="resetTime = $any($event.target).value">
+          <button class="btn-reset" (click)="resetSimulation()" title="Reset">
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M2 8a6 6 0 1 0 1.5-3.97"/>
+              <polyline points="2,2 2,5 5,5"/>
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- SYSTEM LOAD -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">SYSTEM · LOAD</span>
+          <span class="section-meta">CPU</span>
+        </div>
+        <div class="gauge">
+          <div class="gauge-bars">
+            @for (cls of gaugeCells(); track $index) {
+              <div class="gauge-bar" [class]="cls"></div>
+            }
+          </div>
+          <div class="gauge-val" [class.warn]="state.simLoad > 0.7 && state.simLoad <= 0.85"
+                                 [class.crit]="state.simLoad > 0.85">
+            {{ (state.simLoad * 100).toFixed(0) }}<span class="gauge-pct">%</span>
+          </div>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">EVENTS / TICK</span>
+          <span class="row-val">{{ state.eventsPerTick }}</span>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">QUEUE</span>
+          <span class="row-val">{{ state.queueSize }}</span>
+        </div>
+      </div>
+
+    </div>
   </aside>
 
-  <!-- Zoom indicator (dev only) -->
-  @if (isDev) {
-    <div class="zoom-indicator">×{{ (currentScale / fitScale).toFixed(2) }}</div>
-  }
+  <!-- ── Right panel: OUTPUT · TELEMETRY ── -->
+  <aside class="panel panel-right" [class.panel--collapsed]="rightCollapsed">
+    @if (!rightCollapsed) {
+      <div class="panel-head">
+        <button class="panel-toggle panel-toggle--left" (click)="rightCollapsed = true">
+          <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <polyline points="7.5,2.5 4,6 7.5,9.5"/>
+          </svg>
+        </button>
+        <span class="panel-head-title">OUTPUT · TELEMETRY</span>
+        <span class="panel-head-id">CH·02</span>
+      </div>
+    } @else {
+      <button class="panel-toggle panel-toggle--solo" (click)="rightCollapsed = false">
+        <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="4.5,2.5 8,6 4.5,9.5"/>
+        </svg>
+      </button>
+    }
+
+    <div class="panel-body">
+
+      <!-- POPULATION KPI -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">SIM · POPULATION</span>
+          <span class="section-meta">{{ peakLabel }}</span>
+        </div>
+        <div class="kpi">
+          <div class="kpi-val amber">{{ formatCount(state.simulationPeople) }}<span class="unit">PAX</span></div>
+          <div class="kpi-sub">
+            <span>IN METRO <span class="kpi-sub-v">{{ formatCount(state.metroPeople) }}</span></span>
+            <span>· EXT <span class="kpi-sub-v">{{ formatCount(state.simulationPeople - state.metroPeople) }}</span></span>
+          </div>
+        </div>
+        <div class="sparkline-wrap">
+          <svg width="100%" height="22" viewBox="0 0 100 22" preserveAspectRatio="none">
+            <polyline [attr.points]="sparklinePoints(peopleHistory)"
+                      fill="none" stroke="#f5b454" stroke-width="1" opacity="0.9"/>
+          </svg>
+        </div>
+      </div>
+
+      <!-- DISTRIBUTION -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">DISTRIBUTION</span>
+          <span class="section-meta">PAX</span>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">IN TRAINS</span>
+          <span class="row-val" style="color:var(--cyan)">{{ formatCount(state.trainsPeople) }}</span>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">PLATFORMS</span>
+          <span class="row-val">{{ formatCount(allPeople(state.platformsPeople)) }}</span>
+        </div>
+        <div class="stat-row">
+          <span class="row-name">STATION HALL</span>
+          <span class="row-val">{{ formatCount(allPeople(state.stationsPeople)) }}</span>
+        </div>
+      </div>
+
+      <!-- BY LINE -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">SATURATION · BY LINE</span>
+          <span class="section-meta">{{ linePeople().length }} CH</span>
+        </div>
+        @for (line of linePeople(); track line[0]) {
+          <div class="line-row">
+            <div class="line-chip" [style.background]="lineColors(line[0])">{{ line[0] }}</div>
+            <div class="line-bar-bg">
+              <div class="line-bar-fill"
+                   [style.width.%]="linePercent(line[1])"
+                   [style.background]="lineColors(line[0])">
+              </div>
+            </div>
+            <span class="line-count">{{ formatCount(line[1]) }}</span>
+          </div>
+        }
+      </div>
+
+    </div>
+  </aside>
+
+  <!-- Bottom telemetry strip -->
+  <div class="telemetry" [style.--p]="((dayProgress) * 100).toFixed(1) + '%'">
+    <span class="telemetry-tag">▸ NET</span>
+    <div class="telemetry-track"></div>
+    <div class="telemetry-stat"><span class="k">TRAINS</span><span class="v">{{ telemetryTrains }}</span></div>
+    <div class="telemetry-stat"><span class="k">SEGMENTS</span><span class="v">{{ telemetrySegments }}</span></div>
+    <div class="telemetry-stat"><span class="k">STATIONS</span><span class="v">{{ telemetryStations }}</span></div>
+    <div class="telemetry-stat"><span class="k">UPTIME</span><span class="v">{{ telemetryUptime }}m</span></div>
+  </div>
 
   <!-- Zoom controls -->
+  <div class="zoom-readout">{{ zoomReadout }}</div>
   <div class="zoom-bar">
-    <button class="zoom-btn" (click)="zoomIn()"    title="Zoom in">
-      <span class="material-icons">add</span>
+    <button class="zoom-btn" (click)="zoomIn()" title="Zoom in">
+      <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
+        <path d="M6 2v8M2 6h8"/>
+      </svg>
     </button>
-    <div class="zoom-sep"></div>
-    <button class="zoom-btn" (click)="zoomOut()"   title="Zoom out">
-      <span class="material-icons">remove</span>
+    <button class="zoom-btn" (click)="zoomOut()" title="Zoom out">
+      <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
+        <path d="M2 6h8"/>
+      </svg>
     </button>
-    <div class="zoom-sep"></div>
-    <button class="zoom-btn" (click)="zoomReset()" title="Reset zoom">
-      <span class="material-icons">center_focus_strong</span>
+    <button class="zoom-btn" (click)="zoomReset()" title="Recenter">
+      <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3">
+        <circle cx="8" cy="8" r="3"/>
+        <path d="M8 1v2.5M8 12.5V15M1 8h2.5M12.5 8H15" stroke-linecap="round"/>
+      </svg>
     </button>
   </div>
 

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -87,7 +87,8 @@ describe('TrainComponent', () => {
     expect(component.lineColors('1')).not.toBe('');
   });
 
-  it('lineColors should return red for unknown lines', () => {
-    expect(component.lineColors('999')).toBe('red');
+  it('lineColors should return a fallback color for unknown lines', () => {
+    expect(component.lineColors('999')).toBeTruthy();
+    expect(component.lineColors('999')).not.toBe('');
   });
 });

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -114,7 +114,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
           this.state.reset();
         }
         this.state.process(msg);
-        this.cd.detectChanges();
+        this.cd.markForCheck();
       });
 
     this.ngZone.runOutsideAngular(() => this.startRenderLoop());
@@ -504,7 +504,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.time = ((h || 6) * 3600 + (m || 0)) * 1000;
     this.state.reset();
     this.wsService.send({ message: 'reset' });
-    this.cd.detectChanges();
+    this.cd.markForCheck();
   }
 
   // ── Load gauge ────────────────────────────────────────────────

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -30,12 +30,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   leftCollapsed  = false;
   rightCollapsed = false;
 
-  // Zoom state — exposed to template for the dev indicator
   currentScale = 1;
   protected fitScale  = 1;
   readonly isDev = !environment.production;
 
-  // Pan state (screen pixels: where world origin maps to)
   private panX = 0;
   private panY = 0;
 
@@ -51,24 +49,25 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   private readonly destroy$ = new Subject<void>();
   private destroyed = false;
 
-  // Speed presets: local multiplier on top of backend timeMultiplier
-  private static readonly SPEED_PRESETS = [0.25, 0.5, 1, 2, 5, 10, 20];
-  private speedIdx = 2; // default ×1
+  static readonly SPEED_PRESETS = [0.25, 0.5, 1, 2, 5, 10, 20];
+  private speedIdx = 2;
   get localSpeed(): number { return TrainComponent.SPEED_PRESETS[this.speedIdx]; }
+  get speedPresets(): number[] { return TrainComponent.SPEED_PRESETS; }
+  get speedIdx_(): number { return this.speedIdx; }
 
-  // Reset clock target
   resetTime = '06:05';
 
-  // Label visibility pre-computed at fitScale — stable set across all zoom levels
   private labelVisible: boolean[] = [];
 
-  // Fixed screen-pixel sizes (divide by currentScale when drawing in world coords)
+  // Sparkline history
+  peopleHistory: number[] = Array(40).fill(0);
+
   private static readonly PATH_WIDTH_PX      = 6;
   private static readonly DOT_RADIUS_PX      = 5;
   private static readonly DOT_STROKE_PX      = 1.2;
-  private static readonly LABEL_SIZE_PX      = 11;   // low-zoom target (screen px)
-  private static readonly LABEL_SIZE_ZOOM_PX = 13;   // high-zoom target (screen px)
-  private static readonly LABEL_SHOW_ALL_MUL = 2.5;  // show all labels above this zoom multiplier
+  private static readonly LABEL_SIZE_PX      = 11;
+  private static readonly LABEL_SIZE_ZOOM_PX = 13;
+  private static readonly LABEL_SHOW_ALL_MUL = 2.5;
 
   constructor(
     private readonly wsService: WebSocketService,
@@ -96,15 +95,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.needsStaticRedraw = true;
     this.needsTrainRedraw  = true;
 
-    // Align backend speed with the frontend stepper on connect (×1 = real time)
     this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
 
     this.wsService.messages$
       .pipe(takeUntil(this.destroy$))
       .subscribe(msg => {
         if (msg.message === 'simTime') {
-          // On first receipt (snapshot), sync clock to backend sim time.
-          // On subsequent ticks, only resync if drift > 5 sim-seconds to avoid jitter.
           const drift = Math.abs(this.time - msg.ms);
           if (!this.clockSynced || drift > 5_000) {
             this.time = msg.ms;
@@ -163,7 +159,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       }
     }
 
-    const margin = 40; // screen px padding around the network
+    const margin = 40;
     const netW   = maxX - minX;
     const netH   = maxY - minY;
     this.fitScale    = Math.min((vW - margin * 2) / netW, (vH - margin * 2) / netH);
@@ -174,7 +170,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   // ── Transform helpers ────────────────────────────────────────
 
-  // Sets the ctx transform so world coords → physical canvas pixels
   private applyTransform(ctx: CanvasRenderingContext2D): void {
     ctx.setTransform(
       this.currentScale * this.dpr, 0,
@@ -184,7 +179,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     );
   }
 
-  // Clears the entire physical canvas (ignores current transform)
   private clearCtx(ctx: CanvasRenderingContext2D): void {
     ctx.setTransform(1, 0, 0, 1, 0, 0);
     ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
@@ -195,7 +189,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   private setupEvents(): void {
     const container = this.canvasContainer.nativeElement as HTMLElement;
 
-    // Wheel: zoom toward cursor
     container.addEventListener('wheel', (e: WheelEvent) => {
       e.preventDefault();
       const factor    = e.deltaY < 0 ? 1.12 : 1 / 1.12;
@@ -211,7 +204,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       this.needsTrainRedraw  = true;
     }, { passive: false });
 
-    // Mouse drag: pan
     let dragging = false;
     let lastX = 0, lastY = 0;
     container.addEventListener('mousedown', (e: MouseEvent) => {
@@ -230,7 +222,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     container.addEventListener('mouseup',    endDrag);
     container.addEventListener('mouseleave', endDrag);
 
-    // Window resize: resize canvases and redraw
     window.addEventListener('resize', () => {
       this.resizeCanvases();
       this.needsStaticRedraw = true;
@@ -271,8 +262,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     const loop = (timestamp: number) => {
       if (this.destroyed) return;
 
-      // Advance simulation clock every frame (smooth)
-      // localSpeed IS the speedFactor sent to the backend, so 1 real-ms → localSpeed sim-ms.
       const dt = this.lastRafTimestamp > 0 ? timestamp - this.lastRafTimestamp : 0;
       this.lastRafTimestamp = timestamp;
       if (!this.state.paused) {
@@ -289,9 +278,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       this.state.dirty      = false;
       this.needsTrainRedraw = false;
 
-      // Trigger Angular CD at ~5 fps so the template (clock, people) stays current
       if (timestamp - this.lastCdTick >= 200) {
         this.lastCdTick = timestamp;
+        this.peopleHistory = [...this.peopleHistory.slice(1), this.state.metroPeople];
         this.ngZone.run(() => {});
       }
 
@@ -302,14 +291,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   // ── Label size ───────────────────────────────────────────────
 
-  // Interpolates font target from 11px (at zoom ×2.5) to 13px (at zoom ×5),
-  // giving a smooth growth instead of a hard jump.
   private static readonly LABEL_ZOOM_HIGH = 5.0;
 
   private labelTargetPx(): number {
     const mul  = this.currentScale / this.fitScale;
-    const low  = TrainComponent.LABEL_SHOW_ALL_MUL;  // 2.5
-    const high = TrainComponent.LABEL_ZOOM_HIGH;      // 5.0
+    const low  = TrainComponent.LABEL_SHOW_ALL_MUL;
+    const high = TrainComponent.LABEL_ZOOM_HIGH;
     if (mul <= low)  return TrainComponent.LABEL_SIZE_PX;
     if (mul >= high) return TrainComponent.LABEL_SIZE_ZOOM_PX;
     const t = (mul - low) / (high - low);
@@ -323,10 +310,24 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
-    ctx.lineWidth = TrainComponent.PATH_WIDTH_PX / this.currentScale;
-    ctx.lineJoin  = 'round';
-    ctx.lineCap   = 'round';
+    ctx.lineCap  = 'round';
+    ctx.lineJoin = 'round';
 
+    // Glow pass
+    ctx.globalAlpha = 0.18;
+    for (const segment of this.metroData.paths) {
+      if (segment.path.length < 2) continue;
+      ctx.beginPath();
+      ctx.moveTo(segment.path[0].x, segment.path[0].y);
+      for (const p of segment.path.slice(1)) ctx.lineTo(p.x, p.y);
+      ctx.strokeStyle = this.lineColors(segment.line);
+      ctx.lineWidth = (TrainComponent.PATH_WIDTH_PX * 2) / this.currentScale;
+      ctx.stroke();
+    }
+    ctx.globalAlpha = 1;
+
+    // Main stroke
+    ctx.lineWidth = TrainComponent.PATH_WIDTH_PX / this.currentScale;
     for (const segment of this.metroData.paths) {
       if (segment.path.length < 2) continue;
       ctx.beginPath();
@@ -337,11 +338,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     }
   }
 
-  // Pre-compute which labels to show at fitScale — stable across all zoom levels
   private computeLabelVisibility(): void {
     const scale   = this.fitScale;
     const fontSize = Math.round(TrainComponent.LABEL_SIZE_PX / scale);
-    this.ctxStations.font = `${fontSize}px Inter, Verdana, sans-serif`;
+    this.ctxStations.font = `${fontSize}px 'JetBrains Mono', monospace`;
     const r       = TrainComponent.DOT_RADIUS_PX / scale;
     const padding = 2 / scale;
     const placed: { x: number; y: number; w: number; h: number }[] = [];
@@ -374,17 +374,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     const showAll    = (scale / this.fitScale) >= TrainComponent.LABEL_SHOW_ALL_MUL;
     const fontSize   = Math.round(this.labelTargetPx() / scale);
 
-    ctx.fillStyle   = 'white';
-    ctx.strokeStyle = '#0d1117';
     ctx.lineWidth   = lw;
-    if (showLabels) ctx.font = `${fontSize}px Inter, Verdana, sans-serif`;
+    if (showLabels) ctx.font = `${fontSize}px 'JetBrains Mono', monospace`;
 
     this.metroData.stations.forEach((station, i) => {
       const { x, y } = station.position;
 
       ctx.beginPath();
       ctx.arc(x, y, r, 0, Math.PI * 2);
+      ctx.fillStyle   = '#0c0e11';
       ctx.fill();
+      ctx.strokeStyle = '#e6ebf2';
       ctx.stroke();
       ctx.closePath();
 
@@ -394,9 +394,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         const ly = y + fontSize * 0.35;
         const bw = ctx.measureText(station.name).width + padding * 2;
         const bh = fontSize * 1.1;
-        ctx.fillStyle = '#0d1117';
+        ctx.fillStyle = 'rgba(8,9,11,0.9)';
         ctx.fillRect(lx - padding, ly - fontSize * 0.85, bw, bh);
-        ctx.fillStyle = 'white';
+        ctx.fillStyle = '#e6ebf2';
         ctx.fillText(station.name, lx, ly);
       }
     });
@@ -408,18 +408,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
-    const w  = 18 / scale;   // train length  (screen px / scale = world units)
-    const h  =  7 / scale;   // train height
-    const r  =  h / 2;       // full half-height → pill shape
+    const w  = 18 / scale;
+    const h  =  7 / scale;
+    const r  =  h / 2;
     const lw =  1 / scale;
 
     ctx.lineWidth = lw;
 
     for (const train of this.state.trains) {
-      // Interpolate position between last known position and target
       if (train.travelMs > 0) {
         const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
-        const ease = t * t * (3 - 2 * t); // smoothstep
+        const ease = t * t * (3 - 2 * t);
         train.x = train.fromX + (train.targetX - train.fromX) * ease;
         train.y = train.fromY + (train.targetY - train.fromY) * ease;
       }
@@ -430,26 +429,22 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
       ctx.save();
 
-      // Background fill
       this.pillRect(ctx, x, y, w, h, r);
-      ctx.fillStyle = '#21262d';
+      ctx.fillStyle = '#11141a';
       ctx.fill();
 
-      // Occupancy fill — clipped to pill shape
       ctx.clip();
-      ctx.fillStyle = occ < 0.5 ? '#3fb950' : occ < 0.8 ? '#d29922' : '#f85149';
+      ctx.fillStyle = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
       ctx.fillRect(x, y, w * occ, h);
 
       ctx.restore();
 
-      // Outline
       this.pillRect(ctx, x, y, w, h, r);
-      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+      ctx.strokeStyle = 'rgba(255,255,255,0.3)';
       ctx.stroke();
     }
   }
 
-  // Cross-browser rounded rectangle (pill when r = h/2)
   private pillRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
     ctx.beginPath();
     ctx.moveTo(x + r, y);
@@ -464,7 +459,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     ctx.closePath();
   }
 
-  // ── Clock ────────────────────────────────────────────────────
+  // ── Clock & time ─────────────────────────────────────────────
 
   displayClock(): string {
     return new Date(this.time).toLocaleTimeString('en-GB', {
@@ -473,19 +468,28 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  get dayProgress(): number {
+    return (this.time % 86_400_000) / 86_400_000;
+  }
+
+  // ── Config steppers ──────────────────────────────────────────
+
   stepConfig(field: keyof typeof this.cfg.config, delta: number): void {
     const next = this.cfg.config[field] + delta;
     this.cfg.save({ ...this.cfg.config, [field]: next });
   }
 
-  speedDown(): void {
-    this.speedIdx = Math.max(0, this.speedIdx - 1);
+  // ── Speed ────────────────────────────────────────────────────
+
+  setSpeedIdx(i: number): void {
+    this.speedIdx = i;
     this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
   }
-  speedUp(): void {
-    this.speedIdx = Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1);
-    this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
-  }
+
+  speedDown(): void { this.setSpeedIdx(Math.max(0, this.speedIdx - 1)); }
+  speedUp():   void { this.setSpeedIdx(Math.min(TrainComponent.SPEED_PRESETS.length - 1, this.speedIdx + 1)); }
+
+  // ── Simulation controls ───────────────────────────────────────
 
   playPause(): void {
     if (this.state.paused) {
@@ -503,13 +507,35 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.cd.detectChanges();
   }
 
+  // ── Load gauge ────────────────────────────────────────────────
+
+  readonly gaugeCount = 16;
+  gaugeCells(): string[] {
+    const filled = Math.round(this.state.simLoad * this.gaugeCount);
+    return Array.from({ length: this.gaugeCount }, (_, i) => {
+      if (i >= filled) return '';
+      if (i >= 14) return 'over';
+      if (i >= 11) return 'warn';
+      return 'on';
+    });
+  }
+
+  // ── Formatting helpers ────────────────────────────────────────
+
   formatCount(n: number): string {
-    if (n >= 10_000) return `${Math.round(n / 1000)}k`;
-    if (n >= 1_000)  return `${(n / 1000).toFixed(1)}k`;
+    if (n >= 100_000) return `${Math.round(n / 1000)}k`;
+    if (n >= 10_000)  return `${(n / 1000).toFixed(1)}k`;
+    if (n >= 1_000)   return `${(n / 1000).toFixed(2)}k`;
     return String(n);
   }
 
-  // ── Stats helpers ────────────────────────────────────────────
+  sparklinePoints(values: number[]): string {
+    const w = 100, h = 22;
+    const max = Math.max(...values, 1);
+    return values.map((v, i) => `${(i / (values.length - 1)) * w},${h - (v / max) * h}`).join(' ');
+  }
+
+  // ── Stats helpers ─────────────────────────────────────────────
 
   linePeople(): [string, number][] {
     return Array.from(this.state.platformsPeople.entries())
@@ -526,14 +552,26 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     return Math.round((count / max) * 100);
   }
 
-  computeCheckPeople(): number {
-    return this.state.metroPeople
-      - this.state.trainsPeople
-      - this.allPeople(this.state.platformsPeople)
-      - this.allPeople(this.state.stationsPeople);
+  lineColors(line: string): string {
+    return LINE_COLORS[line] ?? '#6b7488';
   }
 
-  lineColors(line: string): string {
-    return LINE_COLORS[line] ?? 'red';
+  // ── Telemetry strip ───────────────────────────────────────────
+
+  get telemetryTrains(): number   { return this.state.trains.length; }
+  get telemetrySegments(): number { return this.metroData.paths.length; }
+  get telemetryStations(): number { return this.metroData.stations.length; }
+  get telemetryUptime(): number   { return Math.floor(this.time / 60_000) % 999; }
+
+  get zoomReadout(): string {
+    return `×${(this.currentScale / this.fitScale).toFixed(2)}`;
+  }
+
+  get peakLabel(): string {
+    const h = (this.time / 3_600_000) % 24;
+    if (h >= 7.5 && h < 9.5)  return 'PEAK · AM';
+    if (h >= 17  && h < 19.5) return 'PEAK · PM';
+    if (h < 6 || h > 23)      return 'NIGHT';
+    return 'OFF · PEAK';
   }
 }

--- a/metro/src/index.html
+++ b/metro/src/index.html
@@ -2,13 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Metro Simu</title>
+  <title>METRO · OPS</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>METRO · OPS</title>
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 </head>
 <body>

--- a/metro/src/styles.css
+++ b/metro/src/styles.css
@@ -1,5 +1,4 @@
 @use '@angular/material' as mat;
-
 @include mat.core();
 
 $metro-theme: mat.define-theme((
@@ -8,29 +7,79 @@ $metro-theme: mat.define-theme((
     primary: mat.$azure-palette,
   ),
 ));
+html { @include mat.all-component-themes($metro-theme); height: 100%; }
 
-html {
-  @include mat.all-component-themes($metro-theme);
-  height: 100%;
+/* ════════════════════════════════════════════════════════════
+   METRO OPS · control room design system
+   ════════════════════════════════════════════════════════════ */
+
+:root {
+  --bg-0: #08090b;
+  --bg-1: #0c0e11;
+  --bg-2: #11141a;
+  --bg-3: #161a22;
+  --bg-4: #1d2230;
+
+  --line-1: #1c2230;
+  --line-2: #262e3f;
+  --line-3: #364056;
+
+  --t-1: #e6ebf2;
+  --t-2: #a8b1c1;
+  --t-3: #6b7488;
+  --t-4: #444c5e;
+
+  --ok:   #4ade80;
+  --warn: #fbbf24;
+  --crit: #f87171;
+  --info: #60a5fa;
+
+  --amber:     #f5b454;
+  --amber-dim: #b88438;
+  --cyan:      #6ad9d9;
+  --cyan-dim:  #3a8888;
+
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --sans: 'Space Grotesk', system-ui, -apple-system, sans-serif;
 }
 
-*, *::before, *::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body { height: 100%; }
 
 body {
-  height: 100%;
-  background: #0d1117;
-  color: #e6edf3;
-  font-family: 'Inter', system-ui, sans-serif;
-  font-size: 13px;
+  background: var(--bg-0);
+  color: var(--t-1);
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.4;
   overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: geometricPrecision;
 }
 
+button { font: inherit; color: inherit; cursor: pointer; }
+
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--line-2); }
+::-webkit-scrollbar-thumb:hover { background: var(--line-3); }
+
 app-root {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-rows: 44px 1fr;
   height: 100vh;
+  background: var(--bg-1);
 }
+
+/* ── Material dialog overlay reset ─────────────────────── */
+.cdk-overlay-backdrop {
+  background: rgba(0, 0, 0, 0.72) !important;
+  backdrop-filter: blur(4px);
+}
+.mat-mdc-dialog-container { box-shadow: none !important; background: transparent !important; }
+.mat-mdc-dialog-surface { background: transparent !important; box-shadow: none !important; padding: 0 !important; }
+
+@keyframes fadein  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes slideup { from { transform: translateY(8px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+@keyframes pulse   { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }

--- a/metro/src/styles.css
+++ b/metro/src/styles.css
@@ -66,8 +66,8 @@ button { font: inherit; color: inherit; cursor: pointer; }
 ::-webkit-scrollbar-thumb:hover { background: var(--line-3); }
 
 app-root {
-  display: grid;
-  grid-template-rows: 44px 1fr;
+  display: flex;
+  flex-direction: column;
   height: 100vh;
   background: var(--bg-1);
 }


### PR DESCRIPTION
## Summary

- **Header**: brand mark crosshair, NODE/SESSION/TICK/×SPEED meta strip, animated connection chip (green/amber/red dot with glow)
- **Left panel (CONTROL·INPUT)**: large amber sim clock with tape progress bar, fleet config steppers, 7-preset speed row (×0.25–×20), sim controls, 16-cell VU meter CPU load gauge
- **Right panel (OUTPUT·TELEMETRY)**: KPI population counter with SVG sparkline, distribution rows, per-line saturation bars with colored chips
- **Canvas**: line glow pass, dark-fill station dots, control-room occupancy colors (green/amber/red) on train pills
- **Chrome**: corner brackets, scope crosshair, bottom telemetry strip (trains/segments/stations/uptime), zoom readout chip
- **Config dialog**: fully custom control-room styled (slider + number input, amber summary bar), no Material components in template
- **Global**: CSS custom properties (near-black palette + amber phosphor accent), JetBrains Mono + Space Grotesk, faint grid backdrop

## Test plan

- [ ] Mapa visible con líneas, estaciones y trenes animados
- [ ] Panel izquierdo: reloj avanza, tape se mueve, presets de velocidad cambian velocidad
- [ ] Panel derecho: stats actualizados desde WebSocket, sparkline se anima
- [ ] Botón play/pause funciona sin errores NG0100 en consola
- [ ] Diálogo de config abre con el nuevo estilo, sliders y números sincronizados, Apply guarda
- [ ] Paneles colapsan/expanden correctamente
- [ ] Zoom in/out/reset funciona