### PR TITLE
feat: articulated trains, realistic schedule, direction arrow

### DIFF
--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.{Failure, Random, Success}
 
 import org.apache.pekko.actor.typed.{ActorRef, ActorSystem, Behavior}
-import org.apache.pekko.actor.typed.scaladsl.Behaviors
+import org.apache.pekko.actor.typed.scaladsl.{ActorContext, Behaviors}
 import org.apache.pekko.actor.typed.scaladsl.adapter._
 import org.apache.pekko.http.scaladsl.Http
 import org.apache.pekko.http.scaladsl.server.Directives.{handleWebSocketMessages, path}
@@ -35,6 +35,8 @@ object Main {
     scribe.info(s"Metro starting. Sim speed: ${speedFactor}× real time")
     SimClock.setSpeed(speedFactor)
     SimClock.start()
+    // Pre-populate snapshot so connecting clients know simulation starts paused
+    WebSocket.sendStat("simPaused", """{"message": "simPaused", "paused": true}""")
 
     // Get daily entrance data
     val entrance: String = scala.io.Source.fromFile("data/entrance.json").mkString
@@ -90,8 +92,8 @@ object Main {
       if (text.contains("\"reset\"")) {
         SimClock.reset()
         WebSocket.resetSnapshot()
+        WebSocket.sendStat("simPaused", """{"message": "simPaused", "paused": true}""")
         CommandBus.fireReset()
-        broadcastPaused()
       } else if (text.contains("\"setSpeed\"")) {
         val factor = text.split("\"factor\"\\s*:\\s*").drop(1).headOption
           .flatMap(_.trim.takeWhile(c => c.isDigit || c == '.').toDoubleOption)
@@ -124,6 +126,15 @@ object Main {
 object Guardian {
 
   sealed trait Command
+  case class AdjustTrainsForHour(hour: Int) extends Command
+
+  // Fraction of max trains per line per hour (Madrid Metro schedule approximation)
+  private val TrainFractionByHour: Map[Int, Double] = Map(
+    6 -> 0.35, 7 -> 0.55, 8 -> 0.90, 9 -> 0.90, 10 -> 0.70,
+    11 -> 0.60, 12 -> 0.60, 13 -> 0.65, 14 -> 0.70, 15 -> 0.65,
+    16 -> 0.60, 17 -> 0.80, 18 -> 0.90, 19 -> 0.90, 20 -> 0.75,
+    21 -> 0.60, 22 -> 0.45, 23 -> 0.30
+  )
 
   def apply(
     metroConf: MetroConf,
@@ -188,21 +199,39 @@ object Guardian {
             }
         }
 
-      // Build trains — keep refs so we can reset them later
       val random = new Random
-      val percentageOfStationsWithTrains = 80
-      val trainActors = scala.collection.mutable.Buffer[ActorRef[TrainMessage]]()
-      platformActors.foreach { case (_, linePlatforms) =>
+
+      // Helper: spawn a single train on a random platform of the given line
+      def spawnTrain(platforms: Seq[ActorRef[PlatformMessage]]): ActorRef[TrainMessage] = {
+        val start = platforms(random.nextInt(platforms.size))
+        val uuid  = java.util.UUID.randomUUID.toString
+        val train = context.spawn(Train(ui, allPaths), uuid)
+        train ! Move(start)
+        train
+      }
+
+      // Mutable train tracking per line
+      val trainsByLine = scala.collection.mutable.Map[String, scala.collection.mutable.Buffer[ActorRef[TrainMessage]]]()
+
+      // Initialize trains for 6 am (start of service)
+      platformActors.foreach { case (lineKey, linePlatforms) =>
         val platforms = linePlatforms.values.toSeq
-        val trainCount = (percentageOfStationsWithTrains * platforms.length / 100) + 1
-        for (_ <- 1 to trainCount) {
-          val start = platforms(random.nextInt(platforms.size))
-          val uuid  = java.util.UUID.randomUUID.toString
-          val train = context.spawn(Train(ui, allPaths), uuid)
-          train ! Move(start)
-          trainActors += train
+        val maxTrains = math.max(1, platforms.size / 2)
+        val initialCount = math.max(1, math.round(TrainFractionByHour(6) * maxTrains).toInt)
+        val buf = scala.collection.mutable.Buffer[ActorRef[TrainMessage]]()
+        for (_ <- 1 to initialCount) buf += spawnTrain(platforms)
+        trainsByLine(lineKey) = buf
+        scribe.info(s"Line $lineKey: $initialCount trains at 06:00 (max $maxTrains)")
+      }
+
+      // Schedule hourly train count adjustments
+      def scheduleHourlyAdjustments(): Unit = {
+        for (h <- 7 to 23) {
+          val targetSimMs = h.toLong * 3600L * 1000L
+          SimClock.scheduleAt(targetSimMs) { () => context.self ! AdjustTrainsForHour(h) }
         }
       }
+      scheduleHourlyAdjustments()
 
       // Simulator
       val allStationAndPlatformActors: List[ActorRef[_]] =
@@ -213,18 +242,42 @@ object Guardian {
         "simulator"
       )
 
-      // Register CommandBus reset handler — called from WebSocket thread on reset command
       val allPlatformSeq = allPlatformActors.values.toSeq
+
       CommandBus.onReset { () =>
         stationActors.values.foreach(_ ! ResetStation)
         allPlatformActors.values.foreach(_ ! ResetPlatform)
-        trainActors.foreach { train =>
+        trainsByLine.values.flatten.foreach { train =>
           val p = allPlatformSeq(random.nextInt(allPlatformSeq.size))
           train ! ResetTrain(p)
         }
         simulatorRef ! ResetSimulator
+        scheduleHourlyAdjustments()
       }
 
-      Behaviors.empty[Command]
+      Behaviors.receiveMessage[Command] {
+        case AdjustTrainsForHour(h) =>
+          val fraction = TrainFractionByHour.getOrElse(h, 0.30)
+          platformActors.foreach { case (lineKey, linePlatforms) =>
+            val platforms = linePlatforms.values.toSeq
+            val maxTrains = math.max(1, platforms.size / 2)
+            val target  = math.max(1, math.round(fraction * maxTrains).toInt)
+            val buf     = trainsByLine(lineKey)
+            val current = buf.size
+            if (target > current) {
+              val adding = target - current
+              for (_ <- 1 to adding) buf += spawnTrain(platforms)
+              scribe.info(s"Hour $h: +$adding trains on line $lineKey → ${buf.size}/${maxTrains}")
+            } else if (target < current) {
+              val retiring = current - target
+              buf.take(retiring).toSeq.foreach { t =>
+                t ! RetireTrain
+                buf -= t
+              }
+              scribe.info(s"Hour $h: -$retiring trains on line $lineKey → ${buf.size}/${maxTrains}")
+            }
+          }
+          Behaviors.same
+      }
     }
 }

--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -201,27 +201,46 @@ object Guardian {
 
       val random = new Random
 
-      // Helper: spawn a single train on a random platform of the given line
-      def spawnTrain(platforms: Seq[ActorRef[PlatformMessage]]): ActorRef[TrainMessage] = {
-        val start = platforms(random.nextInt(platforms.size))
+      // Spawn a train at a specific platform
+      def spawnTrainAt(start: ActorRef[PlatformMessage]): ActorRef[TrainMessage] = {
         val uuid  = java.util.UUID.randomUUID.toString
         val train = context.spawn(Train(ui, allPaths), uuid)
         train ! Move(start)
         train
       }
 
+      // Spawn a train at a random platform (used for dynamic additions mid-service)
+      def spawnTrainRandom(platforms: Seq[ActorRef[PlatformMessage]]): ActorRef[TrainMessage] =
+        spawnTrainAt(platforms(random.nextInt(platforms.size)))
+
+      // Sorted platforms for a line (matches the physical track order)
+      def sortedPlatformsForLine(lineKey: String, linePlatforms: Map[String, ActorRef[PlatformMessage]]): Seq[ActorRef[PlatformMessage]] = {
+        val sorted = sortedLinePaths
+          .getOrElse(lineKey, Seq.empty)
+          .flatMap { p =>
+            val name = Metro.platformName(p.features.denominacion, p.features.codigoanden)
+            linePlatforms.get(name)
+          }
+        if (sorted.nonEmpty) sorted else linePlatforms.values.toSeq
+      }
+
       // Mutable train tracking per line
       val trainsByLine = scala.collection.mutable.Map[String, scala.collection.mutable.Buffer[ActorRef[TrainMessage]]]()
 
-      // Initialize trains for 6 am (start of service)
+      // Initialize trains for 6 am — evenly spaced along the sorted platform sequence
       platformActors.foreach { case (lineKey, linePlatforms) =>
-        val platforms = linePlatforms.values.toSeq
+        val platforms = sortedPlatformsForLine(lineKey, linePlatforms)
         val maxTrains = math.max(1, platforms.size / 2)
         val initialCount = math.max(1, math.round(TrainFractionByHour(6) * maxTrains).toInt)
+        val step   = platforms.size.toDouble / initialCount
+        val offset = random.nextInt(platforms.size)
         val buf = scala.collection.mutable.Buffer[ActorRef[TrainMessage]]()
-        for (_ <- 1 to initialCount) buf += spawnTrain(platforms)
+        for (i <- 0 until initialCount) {
+          val idx = (offset + (i * step).toInt) % platforms.size
+          buf += spawnTrainAt(platforms(idx))
+        }
         trainsByLine(lineKey) = buf
-        scribe.info(s"Line $lineKey: $initialCount trains at 06:00 (max $maxTrains)")
+        scribe.info(s"Line $lineKey: $initialCount trains at 06:00 (max $maxTrains, step=${step.toInt})")
       }
 
       // Schedule hourly train count adjustments
@@ -266,7 +285,7 @@ object Guardian {
             val current = buf.size
             if (target > current) {
               val adding = target - current
-              for (_ <- 1 to adding) buf += spawnTrain(platforms)
+              for (_ <- 1 to adding) buf += spawnTrainRandom(platforms)
               scribe.info(s"Hour $h: +$adding trains on line $lineKey → ${buf.size}/${maxTrains}")
             } else if (target < current) {
               val retiring = current - target

--- a/metro-sim/src/main/scala/SimClock.scala
+++ b/metro-sim/src/main/scala/SimClock.scala
@@ -30,7 +30,7 @@ object SimClock {
   @volatile private var _simTimeMs:       Long    = 6L * 3600L * 1000L  // starts at 06:00
   @volatile private var _speedFactor:     Double  = 10.0               // default: 10× real time
   @volatile private var _running:         Boolean = false
-  @volatile private var _paused:          Boolean = false
+  @volatile private var _paused:          Boolean = true
 
   def isPaused: Boolean = _paused
   def pause():  Unit    = { _paused = true }

--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -38,6 +38,7 @@ object Train {
 
         var platform: Option[ActorRef[PlatformMessage]] = None
         var nextPlatform: Option[ActorRef[PlatformMessage]] = None
+        var retiring = false
         var x: Double = 0
         var y: Double = 0
         val trainName = context.self.path.name
@@ -62,10 +63,10 @@ object Train {
             if (platform.isEmpty) {
               platform = Some(p)
               scribe.debug(s"Train $trainName starting at ${p.path.name}")
-              findPlatformPath(p).foreach { pp =>
-                x = pp.x; y = pp.y
-                WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, isNew = true)
-              }
+              val pp = findPlatformPath(p)
+              pp.foreach { path => x = path.x; y = path.y }
+              val anden = pp.map(_.features.codigoanden).getOrElse(0)
+              WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, isNew = true)
               SimClock.scheduleIn(travelMs()) { () =>
                 platform.foreach(_ ! GetNextPlatform(selfRef))
               }
@@ -82,13 +83,24 @@ object Train {
             platform = nextPlatform
             platform.get ! ArrivedAtPlatform(selfRef)
             people.foreach { case (_, person) => person ! ArrivedAtPlatformToPeople(platform.get) }
-            findPlatformPath(platform.get).foreach { pp => x = pp.x; y = pp.y }
-            WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, isNew = false)
+            val pp = findPlatformPath(platform.get)
+            pp.foreach { path => x = path.x; y = path.y }
+            val anden = pp.map(_.features.codigoanden).getOrElse(0)
+            WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, isNew = false)
             nextPlatform = None
-            SimClock.scheduleIn(doorsMs()) { () =>
-              platform.foreach(_ ! GetNextPlatform(selfRef))
+            if (retiring) {
+              scribe.info(s"Train $trainName retiring after arrival at platform")
+              SimClock.scheduleIn(doorsMs()) { () =>
+                platform.foreach(_ ! LeavingPlatform)
+                WebSocket.removeTrain(trainName)
+              }
+              Behaviors.stopped
+            } else {
+              SimClock.scheduleIn(doorsMs()) { () =>
+                platform.foreach(_ ! GetNextPlatform(selfRef))
+              }
+              Behaviors.same
             }
-            Behaviors.same
 
           case NextPlatformForTrain(p) =>
             nextPlatform = Some(p)
@@ -102,7 +114,9 @@ object Train {
             Behaviors.same
 
           case RequestEnterTrain(person) =>
-            if (people.size < MAX_CAPACITY) {
+            if (retiring) {
+              person ! NotAcceptedEnterTrain
+            } else if (people.size < MAX_CAPACITY) {
               people(person.path.name) = person
               person ! AcceptedEnterTrain(platform.get)
             } else {
@@ -116,11 +130,17 @@ object Train {
             people.remove(personId)
             Behaviors.same
 
+          case RetireTrain =>
+            scribe.info(s"Train $trainName marked for retirement")
+            retiring = true
+            Behaviors.same
+
           case ResetTrain(startPlatform) =>
             scribe.debug(s"Train $trainName resetting")
             people.clear()
             platform     = None
             nextPlatform = None
+            retiring     = false
             x = 0; y = 0
             startPlatform ! ReservePlatform(selfRef)
             Behaviors.same

--- a/metro-sim/src/main/scala/messages/Messages.scala
+++ b/metro-sim/src/main/scala/messages/Messages.scala
@@ -50,6 +50,7 @@ object Messages {
   case class ExitTrain(personId: String) extends TrainMessage
   case object TrainStatsTick extends TrainMessage
   case class ResetTrain(startPlatform: ActorRef[PlatformMessage]) extends TrainMessage
+  case object RetireTrain extends TrainMessage
 
   // ─── Line messages (sent TO a Line actor) ─────────────────────────────────
   sealed trait LineMessage

--- a/metro-sim/src/main/scala/utils/WebSocket.scala
+++ b/metro-sim/src/main/scala/utils/WebSocket.scala
@@ -59,15 +59,21 @@ object WebSocket {
   }
 
   /** Send a train position event and update the snapshot. */
-  def sendTrain(trainId: String, x: Double, y: Double, people: Int, capacity: Int, isNew: Boolean): Unit = {
+  def sendTrain(trainId: String, x: Double, y: Double, people: Int, capacity: Int, anden: Int, isNew: Boolean): Unit = {
     val liveType = if (isNew) "newTrain" else "moveTrain"
-    val liveJson = s"""{"message": "$liveType", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity}"""
+    val liveJson = s"""{"message": "$liveType", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden}"""
     // Snapshot always as newTrain so reconnecting clients (re)create the train
     WebSocket.synchronized {
       snapshot(s"train:$trainId") =
-        s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity}"""
+        s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden}"""
     }
     broadcast(liveJson)
+  }
+
+  /** Remove a train from the snapshot and notify clients. */
+  def removeTrain(trainId: String): Unit = {
+    WebSocket.synchronized { snapshot.remove(s"train:$trainId") }
+    broadcast(s"""{"message": "removeTrain", "train": "$trainId"}""")
   }
 
   /** Send a stat message and update the snapshot under the given key. */

--- a/metro/src/app/constants.ts
+++ b/metro/src/app/constants.ts
@@ -6,6 +6,20 @@ export const CANVAS_HEIGHT = 2000;
 // How often (ms) the train canvas layer is redrawn
 export const REDRAW_PERIOD_MS = 2000;
 
+// Number of wagons per metro line (Madrid Metro)
+export const TRAIN_WAGONS: Record<string, number> = {
+  '1': 6, '2': 6, '3': 6, '4': 4, '5': 6,
+  '6-1': 6, '6-2': 6, '7a': 6, '7b': 6, '8': 6,
+  '9A': 6, '9B': 6, '10a': 6, '10b': 6, '11': 4,
+  '12-1': 6, '12-2': 6, 'R': 3,
+};
+export const DEFAULT_WAGONS = 6;
+
+// Wagon dimensions in canvas coordinate space (scale with zoom)
+export const WAGON_W    = 3.5;
+export const WAGON_H    = 3.0;
+export const WAGON_GAP  = 0.5;
+
 // Colors per metro line (key = line identifier used in simulation messages)
 export const LINE_COLORS: Record<string, string> = {
   '1': '#0097C9',

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -5,6 +5,7 @@ export interface MoveTrain {
   y: number;
   people?: number;
   capacity?: number;
+  anden?: number;
 }
 
 export interface PeopleInLinePlatforms {
@@ -41,6 +42,12 @@ export interface NewTrain {
   y: number;
   people?: number;
   capacity?: number;
+  anden?: number;
+}
+
+export interface RemoveTrain {
+  message: 'removeTrain';
+  train: string;
 }
 
 export interface TimeMultiplier {
@@ -89,6 +96,7 @@ export type SimulationMessage =
   | PeopleInMetro
   | PeopleInSimulation
   | NewTrain
+  | RemoveTrain
   | TimeMultiplier
   | PlatformOvercrowded
   | StationOvercrowded

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -9,6 +9,7 @@ export class SimulationStateService {
   // Keyed by train ID so newTrain from a snapshot replay does an upsert, not a duplicate push
   private readonly trainsMap = new Map<string, Train>();
   get trains(): Train[] { return Array.from(this.trainsMap.values()); }
+  getTrain(id: string): Train | undefined { return this.trainsMap.get(id); }
 
   dirty = false;
   simulationPeople = 0;
@@ -53,6 +54,7 @@ export class SimulationStateService {
           train.travelMs = 135_000 * this.timeMultiplier;
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
+          if (msg.anden    !== undefined) train.anden    = msg.anden;
           this.dirty = true;
         }
         break;
@@ -68,9 +70,17 @@ export class SimulationStateService {
           existing.travelMs = 135_000 / this.timeMultiplier;
           if (msg.people   !== undefined) existing.people   = msg.people;
           if (msg.capacity !== undefined) existing.capacity = msg.capacity;
+          if (msg.anden    !== undefined) existing.anden    = msg.anden;
         } else {
-          this.trainsMap.set(msg.train, new Train(msg.train, msg.x, msg.y, msg.people ?? 0, msg.capacity ?? 600));
+          const t = new Train(msg.train, msg.x, msg.y, msg.people ?? 0, msg.capacity ?? 600);
+          if (msg.anden !== undefined) t.anden = msg.anden;
+          this.trainsMap.set(msg.train, t);
         }
+        this.dirty = true;
+        break;
+      }
+      case 'removeTrain': {
+        this.trainsMap.delete(msg.train);
         this.dirty = true;
         break;
       }

--- a/metro/src/app/train.ts
+++ b/metro/src/app/train.ts
@@ -14,6 +14,9 @@ export class Train {
   anden: number;
   // Path geometry for track-following animation
   pathPoints: { x: number; y: number }[];
+  pathArcLens: number[];   // cached cumulative arc lengths for pathPoints
+  pathSegStart: number;    // arc position where the current tramo starts inside composite
+  pathSegEnd: number;      // arc position where the current tramo ends inside composite
   heading: number;
   line: string;
 
@@ -31,6 +34,9 @@ export class Train {
     this.capacity = capacity;
     this.anden = 0;
     this.pathPoints = [];
+    this.pathArcLens = [];
+    this.pathSegStart = 0;
+    this.pathSegEnd = 0;
     this.heading = 0;
     this.line = '';
   }

--- a/metro/src/app/train.ts
+++ b/metro/src/app/train.ts
@@ -11,6 +11,11 @@ export class Train {
   travelMs: number;
   people: number;
   capacity: number;
+  anden: number;
+  // Path geometry for track-following animation
+  pathPoints: { x: number; y: number }[];
+  heading: number;
+  line: string;
 
   constructor(id: string, x: number, y: number, people = 0, capacity = 600) {
     this.id = id;
@@ -24,5 +29,9 @@ export class Train {
     this.travelMs = 0;
     this.people = people;
     this.capacity = capacity;
+    this.anden = 0;
+    this.pathPoints = [];
+    this.heading = 0;
+    this.line = '';
   }
 }

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -120,10 +120,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
           if (train) {
             const seg = this.metroData.paths.find(s => s.id === String(msg.anden));
             if (seg && seg.path.length >= 2) {
-              train.pathPoints = seg.path;
+              const { path, segStart, segEnd } = this.buildCompositePath(seg);
+              train.pathPoints    = path;
+              train.pathArcLens   = this.computeArcLens(path);
+              train.pathSegStart  = segStart;
+              train.pathSegEnd    = segEnd;
               train.line = seg.line;
-              const last = seg.path[seg.path.length - 1];
-              const prev = seg.path[seg.path.length - 2];
+              const last = path[path.length - 1];
+              const prev = path[path.length - 2];
               train.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
             }
           }
@@ -422,86 +426,183 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.applyTransform(ctx);
 
     for (const train of this.state.trains) {
-      // Advance position along track geometry (or fall back to straight interpolation)
-      if (train.travelMs > 0) {
-        const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
-        const ease = t * t * (3 - 2 * t);
-        if (train.pathPoints.length >= 2) {
-          const pos = this.interpolateOnPath(train.pathPoints, ease);
-          train.x       = pos.x;
-          train.y       = pos.y;
-          train.heading = pos.heading;
-        } else {
-          train.x = train.fromX + (train.targetX - train.fromX) * ease;
-          train.y = train.fromY + (train.targetY - train.fromY) * ease;
-        }
-      }
-
       const wagons  = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
       const stride  = WAGON_W + WAGON_GAP;
+      const halfLen = (wagons - 1) / 2 * stride;
       const occ     = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;
       const fillClr = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
+      const lineClr = this.lineColors(train.line);
       const r       = WAGON_H * 0.3;
+      const inset   = 0.25;
 
-      ctx.save();
-      ctx.translate(train.x, train.y);
-      ctx.rotate(train.heading);
+      const hasPath = train.pathPoints.length >= 2 && train.pathArcLens.length >= 2;
 
-      for (let i = 0; i < wagons; i++) {
-        const ox = (i - (wagons - 1) / 2) * stride;
-        const wx = ox - WAGON_W / 2;
-        const wy = -WAGON_H / 2;
-        // Dark body
-        this.roundedRect(ctx, wx, wy, WAGON_W, WAGON_H, r);
+      // frontArc: arc position of the train's NOSE on the composite path.
+      // Anchoring by the nose means wagons extend backward into the prepended
+      // tramos and the arrow extends forward into the appended tramo — no clamping.
+      let frontArc = 0;
+      if (hasPath) {
+        const segStart = train.pathSegStart;
+        const segEnd   = train.pathSegEnd;
+        if (train.travelMs > 0) {
+          const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
+          const ease = t * t * (3 - 2 * t);
+          frontArc = segStart + ease * (segEnd - segStart);
+        } else {
+          frontArc = segEnd;
+        }
+        const c = this.positionAtArc(train.pathPoints, train.pathArcLens, frontArc - halfLen);
+        train.x = c.x; train.y = c.y; train.heading = c.heading;
+      } else if (train.travelMs > 0) {
+        const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
+        const ease = t * t * (3 - 2 * t);
+        train.x = train.fromX + (train.targetX - train.fromX) * ease;
+        train.y = train.fromY + (train.targetY - train.fromY) * ease;
+      }
+
+      // Draw each wagon independently at its arc position (articulated through curves)
+      for (let i = wagons - 1; i >= 0; i--) {
+        // wagon 0 = rear, wagon wagons-1 = nose
+        const arcOffset = (i - (wagons - 1)) * stride;  // nose at frontArc, rear further back
+        let wx: number, wy: number, wh: number;
+        if (hasPath) {
+          const p = this.positionAtArc(train.pathPoints, train.pathArcLens, frontArc + arcOffset);
+          wx = p.x; wy = p.y; wh = p.heading;
+        } else {
+          wx = train.x; wy = train.y; wh = train.heading;
+        }
+
+        ctx.save();
+        ctx.translate(wx, wy);
+        ctx.rotate(wh);
+
+        this.roundedRect(ctx, -WAGON_W / 2, -WAGON_H / 2, WAGON_W, WAGON_H, r);
         ctx.fillStyle = '#11141a';
         ctx.fill();
-        // Occupancy colour inset
-        const inset = 0.25;
-        this.roundedRect(ctx, wx + inset, wy + inset, WAGON_W - inset * 2, WAGON_H - inset * 2, r * 0.5);
+
+        this.roundedRect(ctx,
+          -WAGON_W / 2 + inset, -WAGON_H / 2 + inset,
+          WAGON_W - inset * 2,   WAGON_H - inset * 2, r * 0.5);
         ctx.fillStyle = fillClr;
         ctx.fill();
-      }
 
-      // Thin border for the whole train at once
-      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
-      ctx.lineWidth   = 0.2;
-      for (let i = 0; i < wagons; i++) {
-        const ox = (i - (wagons - 1) / 2) * stride;
-        this.roundedRect(ctx, ox - WAGON_W / 2, -WAGON_H / 2, WAGON_W, WAGON_H, r);
+        this.roundedRect(ctx, -WAGON_W / 2, -WAGON_H / 2, WAGON_W, WAGON_H, r);
+        ctx.strokeStyle = lineClr;
+        ctx.lineWidth   = 0.35;
         ctx.stroke();
+
+        ctx.restore();
       }
 
+      // Direction arrow ahead of the nose, inside the appended tramo
+      const arrowH   = WAGON_H * 0.8;
+      const arrowArc = frontArc + WAGON_W / 2 + 0.1 + arrowH;
+      let ax: number, ay: number, ah: number;
+      if (hasPath) {
+        const ap = this.positionAtArc(train.pathPoints, train.pathArcLens, arrowArc);
+        ax = ap.x; ay = ap.y; ah = ap.heading;
+      } else {
+        ax = train.x; ay = train.y; ah = train.heading;
+      }
+      ctx.save();
+      ctx.translate(ax, ay);
+      ctx.rotate(ah);
+      ctx.beginPath();
+      ctx.moveTo(arrowH,  0);
+      ctx.lineTo(0,      -arrowH * 0.6);
+      ctx.lineTo(0,       arrowH * 0.6);
+      ctx.closePath();
+      ctx.fillStyle = 'rgba(255,255,255,0.9)';
+      ctx.fill();
       ctx.restore();
     }
   }
 
-  private interpolateOnPath(
-    pts: { x: number; y: number }[],
-    t: number,
-  ): { x: number; y: number; heading: number } {
-    // Cumulative arc lengths
+  // Pre-compute cumulative arc lengths for a path (call once when path changes)
+  private computeArcLens(pts: { x: number; y: number }[]): number[] {
     const lens: number[] = [0];
     for (let i = 1; i < pts.length; i++) {
       const dx = pts[i].x - pts[i - 1].x;
       const dy = pts[i].y - pts[i - 1].y;
       lens.push(lens[i - 1] + Math.sqrt(dx * dx + dy * dy));
     }
-    const total  = lens[lens.length - 1];
-    const target = t * total;
+    return lens;
+  }
+
+  // Return position + heading at a given arc-length along a path (clamps at endpoints).
+  // With composite paths (prev + current tramo) clamping is rarely triggered.
+  private positionAtArc(
+    pts:  { x: number; y: number }[],
+    lens: number[],
+    arc:  number,
+  ): { x: number; y: number; heading: number } {
+    const total   = lens[lens.length - 1];
+    const clamped = Math.max(0, Math.min(total, arc));
 
     let i = 1;
-    while (i < lens.length - 1 && lens[i] < target) i++;
+    while (i < lens.length - 1 && lens[i] < clamped) i++;
 
-    const p0 = pts[i - 1];
-    const p1 = pts[i];
+    const p0     = pts[i - 1];
+    const p1     = pts[i];
     const segLen = lens[i] - lens[i - 1];
-    const segT   = segLen > 0 ? (target - lens[i - 1]) / segLen : 0;
+    const segT   = segLen > 0 ? (clamped - lens[i - 1]) / segLen : 0;
 
     return {
       x:       p0.x + (p1.x - p0.x) * segT,
       y:       p0.y + (p1.y - p0.y) * segT,
       heading: Math.atan2(p1.y - p0.y, p1.x - p0.x),
     };
+  }
+
+  // Build a composite path: up to 2 previous tramos + current tramo + 1 next tramo.
+  // Returns the path and the arc positions of the current tramo's start and end,
+  // so drawTrains can anchor the train nose at segEnd without clamping issues.
+  private buildCompositePath(
+    seg: { id: string; line: string; sentido: string; path: { x: number; y: number }[] },
+  ): { path: { x: number; y: number }[]; segStart: number; segEnd: number } {
+    const CONNECT_SQ = 4;  // ≈ 2 canvas-unit junction tolerance
+    const usedIds = new Set<string>([seg.id]);
+
+    // ── Prepend up to 2 previous tramos (rear-wagon room) ──────────────────
+    let prepended: { x: number; y: number }[] = [];
+    let searchFrom = seg.path[0];
+    for (let k = 0; k < 2; k++) {
+      let best = CONNECT_SQ, prev: typeof seg | null = null;
+      for (const s of this.metroData.paths) {
+        if (s.line !== seg.line || s.sentido !== seg.sentido) continue;
+        if (usedIds.has(s.id) || s.path.length < 2) continue;
+        const e = s.path[s.path.length - 1];
+        const d = (e.x - searchFrom.x) ** 2 + (e.y - searchFrom.y) ** 2;
+        if (d < best) { best = d; prev = s; }
+      }
+      if (!prev) break;
+      prepended  = [...prev.path.slice(0, -1), ...prepended];
+      searchFrom = prev.path[0];
+      usedIds.add(prev.id);
+    }
+
+    // ── Append 1 next tramo (nose + arrow room) ─────────────────────────────
+    let appended: { x: number; y: number }[] = [];
+    const segTail = seg.path[seg.path.length - 1];
+    { // block for scoping
+      let best = CONNECT_SQ, next: typeof seg | null = null;
+      for (const s of this.metroData.paths) {
+        if (s.line !== seg.line || s.sentido !== seg.sentido) continue;
+        if (usedIds.has(s.id) || s.path.length < 2) continue;
+        const d = (s.path[0].x - segTail.x) ** 2 + (s.path[0].y - segTail.y) ** 2;
+        if (d < best) { best = d; next = s; }
+      }
+      if (next) { appended = next.path.slice(1); usedIds.add(next.id); }
+    }
+
+    const path = [...prepended, ...seg.path, ...appended];
+
+    // Compute segStart and segEnd arc positions within the composite path
+    const lens    = this.computeArcLens(path);
+    const segStart = lens[prepended.length];
+    const segEnd   = lens[prepended.length + seg.path.length - 1];
+
+    return { path, segStart, segEnd };
   }
 
   private roundedRect(

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -7,7 +7,7 @@ import { WebSocketService } from '../services/websocket.service';
 import { MetroDataService } from '../services/metro-data.service';
 import { SimulationStateService } from '../services/simulation-state.service';
 import { SimulationConfigService } from '../services/simulation-config.service';
-import { LINE_COLORS } from '../constants';
+import { LINE_COLORS, TRAIN_WAGONS, DEFAULT_WAGONS, WAGON_W, WAGON_H, WAGON_GAP } from '../constants';
 
 @Component({
   selector: 'app-train',
@@ -114,6 +114,20 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
           this.state.reset();
         }
         this.state.process(msg);
+        // Resolve track geometry for path-following animation
+        if ((msg.message === 'newTrain' || msg.message === 'moveTrain') && msg.anden != null) {
+          const train = this.state.getTrain(msg.train);
+          if (train) {
+            const seg = this.metroData.paths.find(s => s.id === String(msg.anden));
+            if (seg && seg.path.length >= 2) {
+              train.pathPoints = seg.path;
+              train.line = seg.line;
+              const last = seg.path[seg.path.length - 1];
+              const prev = seg.path[seg.path.length - 2];
+              train.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
+            }
+          }
+        }
         this.cd.markForCheck();
       });
 
@@ -403,49 +417,97 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   }
 
   private drawTrains(now: number): void {
-    const ctx   = this.ctxTrains;
-    const scale = this.currentScale;
+    const ctx = this.ctxTrains;
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
-    const w  = 18 / scale;
-    const h  =  7 / scale;
-    const r  =  h / 2;
-    const lw =  1 / scale;
-
-    ctx.lineWidth = lw;
-
     for (const train of this.state.trains) {
+      // Advance position along track geometry (or fall back to straight interpolation)
       if (train.travelMs > 0) {
         const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
         const ease = t * t * (3 - 2 * t);
-        train.x = train.fromX + (train.targetX - train.fromX) * ease;
-        train.y = train.fromY + (train.targetY - train.fromY) * ease;
+        if (train.pathPoints.length >= 2) {
+          const pos = this.interpolateOnPath(train.pathPoints, ease);
+          train.x       = pos.x;
+          train.y       = pos.y;
+          train.heading = pos.heading;
+        } else {
+          train.x = train.fromX + (train.targetX - train.fromX) * ease;
+          train.y = train.fromY + (train.targetY - train.fromY) * ease;
+        }
       }
 
-      const x   = train.x - w / 2;
-      const y   = train.y - h / 2;
-      const occ = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;
+      const wagons  = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
+      const stride  = WAGON_W + WAGON_GAP;
+      const occ     = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;
+      const fillClr = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
+      const r       = WAGON_H * 0.3;
 
       ctx.save();
+      ctx.translate(train.x, train.y);
+      ctx.rotate(train.heading);
 
-      this.pillRect(ctx, x, y, w, h, r);
-      ctx.fillStyle = '#11141a';
-      ctx.fill();
+      for (let i = 0; i < wagons; i++) {
+        const ox = (i - (wagons - 1) / 2) * stride;
+        const wx = ox - WAGON_W / 2;
+        const wy = -WAGON_H / 2;
+        // Dark body
+        this.roundedRect(ctx, wx, wy, WAGON_W, WAGON_H, r);
+        ctx.fillStyle = '#11141a';
+        ctx.fill();
+        // Occupancy colour inset
+        const inset = 0.25;
+        this.roundedRect(ctx, wx + inset, wy + inset, WAGON_W - inset * 2, WAGON_H - inset * 2, r * 0.5);
+        ctx.fillStyle = fillClr;
+        ctx.fill();
+      }
 
-      ctx.clip();
-      ctx.fillStyle = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
-      ctx.fillRect(x, y, w * occ, h);
+      // Thin border for the whole train at once
+      ctx.strokeStyle = 'rgba(255,255,255,0.25)';
+      ctx.lineWidth   = 0.2;
+      for (let i = 0; i < wagons; i++) {
+        const ox = (i - (wagons - 1) / 2) * stride;
+        this.roundedRect(ctx, ox - WAGON_W / 2, -WAGON_H / 2, WAGON_W, WAGON_H, r);
+        ctx.stroke();
+      }
 
       ctx.restore();
-
-      this.pillRect(ctx, x, y, w, h, r);
-      ctx.strokeStyle = 'rgba(255,255,255,0.3)';
-      ctx.stroke();
     }
   }
 
-  private pillRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number): void {
+  private interpolateOnPath(
+    pts: { x: number; y: number }[],
+    t: number,
+  ): { x: number; y: number; heading: number } {
+    // Cumulative arc lengths
+    const lens: number[] = [0];
+    for (let i = 1; i < pts.length; i++) {
+      const dx = pts[i].x - pts[i - 1].x;
+      const dy = pts[i].y - pts[i - 1].y;
+      lens.push(lens[i - 1] + Math.sqrt(dx * dx + dy * dy));
+    }
+    const total  = lens[lens.length - 1];
+    const target = t * total;
+
+    let i = 1;
+    while (i < lens.length - 1 && lens[i] < target) i++;
+
+    const p0 = pts[i - 1];
+    const p1 = pts[i];
+    const segLen = lens[i] - lens[i - 1];
+    const segT   = segLen > 0 ? (target - lens[i - 1]) / segLen : 0;
+
+    return {
+      x:       p0.x + (p1.x - p0.x) * segT,
+      y:       p0.y + (p1.y - p0.y) * segT,
+      heading: Math.atan2(p1.y - p0.y, p1.x - p0.x),
+    };
+  }
+
+  private roundedRect(
+    ctx: CanvasRenderingContext2D,
+    x: number, y: number, w: number, h: number, r: number,
+  ): void {
     ctx.beginPath();
     ctx.moveTo(x + r, y);
     ctx.lineTo(x + w - r, y);


### PR DESCRIPTION
## Summary

- **Simulación arranca pausada** — SimClock inicia con `_paused=true`; la simulación solo avanza cuando el frontend envía `resume`
- **Horario realista de trenes** — Guardian inicializa al 35% de capacidad (6:00) y ajusta por hora siguiendo la frecuencia del Metro de Madrid (picos al 90% a las 8-9h y 17-19h)
- **Distribución inicial equiespaciada** — los trenes se colocan a intervalos regulares sobre la secuencia ordenada de plataformas, no aleatoriamente
- **Trenes articulados sobre la vía** — cada vagón se posiciona de forma independiente en su punto exacto de la geometría del tramo (arc-length); el tren se dobla en las curvas
- **Path compuesto** (2 tramos anteriores + actual + 1 siguiente) — elimina el clamping; vagones traseros y flecha tienen siempre geometría real
- **Anclaje por el morro** — el tren se referencia por la nariz, los vagones traseros se extienden hacia atrás sin apilarse
- **Flecha de sentido** — triángulo blanco justo por delante del vagón de cabecera, siguiendo la dirección de la vía
- **Borde en color de línea** — permite distinguir trenes solapados
- **`codigoanden` en mensajes WebSocket** — el backend envía el andén en cada update para que el frontend resuelva la geometría
- **`removeTrain` WebSocket** — los trenes retirados desaparecen limpiamente del mapa

## Test plan

- [ ] `sbt run` → simulación arranca pausada, botón play la inicia
- [ ] Al cargar a las 6:00, trenes de cada línea equiespaciados
- [ ] A las 8:00 (sim time) se añaden trenes; a las 23:00 se retiran
- [ ] Trenes siguen la geometría de la vía en curvas pronunciadas (L6, L12)
- [ ] Se ven los 6 vagones en L5, 3 en Ramal, 4 en L4
- [ ] Flecha de dirección visible y pegada al vagón de cabecera
- [ ] Reset funciona correctamente