### PR TITLE
feat: simulator sends real travelMs, frontend uses it directly

### DIFF
--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -15,8 +15,7 @@ object Train {
   private val MAX_CAPACITY = 1000
 
   // Delays in simulation milliseconds (no timeMultiplier — SimClock handles speed)
-  private val MinTravelMs = 90_000L
-  private val MaxTravelMs = 180_000L
+  private val FallbackTravelMs = 122_000L  // network average from MITMA data
   private val MinDoorsMs  = 20_000L
   private val MaxDoorsMs  = 40_000L
   private val FullRetryMs = 30_000L
@@ -25,7 +24,11 @@ object Train {
     Behaviors.setup { context =>
       val rng = new Random
 
-      def travelMs(): Long = MinTravelMs + rng.nextLong(MaxTravelMs - MinTravelMs)
+      def travelMsForPath(p: Option[Path]): Long = p match {
+        case Some(pp) if pp.features.velocidadtramoanterior > 0 && pp.features.longitudtramoanterior > 0 =>
+          (pp.features.longitudtramoanterior / pp.features.velocidadtramoanterior * 3600 * 1000).toLong
+        case _ => FallbackTravelMs
+      }
       def doorsMs():  Long = MinDoorsMs  + rng.nextLong(MaxDoorsMs  - MinDoorsMs)
 
       Behaviors.withTimers { timers =>
@@ -41,6 +44,7 @@ object Train {
         var retiring = false
         var x: Double = 0
         var y: Double = 0
+        var lastTravelSimMs: Long = FallbackTravelMs
         val trainName = context.self.path.name
         val selfRef   = context.self
 
@@ -66,15 +70,17 @@ object Train {
               val pp = findPlatformPath(p)
               pp.foreach { path => x = path.x; y = path.y }
               val anden = pp.map(_.features.codigoanden).getOrElse(0)
-              WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, isNew = true)
-              SimClock.scheduleIn(travelMs()) { () =>
+              WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, travelMs = 0L, isNew = true)
+              SimClock.scheduleIn(travelMsForPath(pp)) { () =>
                 platform.foreach(_ ! GetNextPlatform(selfRef))
               }
             } else {
               scribe.debug(s"Train $trainName departing from ${platform.get.path.name}")
               nextPlatform = Some(p)
               platform.get ! LeavingPlatform
-              SimClock.scheduleIn(travelMs()) { () => selfRef ! TrainArrivedAtPlatform }
+              val nextPp = findPlatformPath(p)
+              lastTravelSimMs = travelMsForPath(nextPp)
+              SimClock.scheduleIn(lastTravelSimMs) { () => selfRef ! TrainArrivedAtPlatform }
             }
             Behaviors.same
 
@@ -86,7 +92,8 @@ object Train {
             val pp = findPlatformPath(platform.get)
             pp.foreach { path => x = path.x; y = path.y }
             val anden = pp.map(_.features.codigoanden).getOrElse(0)
-            WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, isNew = false)
+            val wallClockMs = (lastTravelSimMs.toDouble / SimClock.speedFactor).toLong
+            WebSocket.sendTrain(trainName, x, y, people.size, MAX_CAPACITY, anden, wallClockMs, isNew = false)
             nextPlatform = None
             if (retiring) {
               scribe.info(s"Train $trainName retiring after arrival at platform")

--- a/metro-sim/src/main/scala/utils/WebSocket.scala
+++ b/metro-sim/src/main/scala/utils/WebSocket.scala
@@ -59,13 +59,13 @@ object WebSocket {
   }
 
   /** Send a train position event and update the snapshot. */
-  def sendTrain(trainId: String, x: Double, y: Double, people: Int, capacity: Int, anden: Int, isNew: Boolean): Unit = {
+  def sendTrain(trainId: String, x: Double, y: Double, people: Int, capacity: Int, anden: Int, travelMs: Long, isNew: Boolean): Unit = {
     val liveType = if (isNew) "newTrain" else "moveTrain"
-    val liveJson = s"""{"message": "$liveType", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden}"""
+    val liveJson = s"""{"message": "$liveType", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden, "travelMs": $travelMs}"""
     // Snapshot always as newTrain so reconnecting clients (re)create the train
     WebSocket.synchronized {
       snapshot(s"train:$trainId") =
-        s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden}"""
+        s"""{"message": "newTrain", "train": "$trainId", "x": $x, "y": $y, "people": $people, "capacity": $capacity, "anden": $anden, "travelMs": 0}"""
     }
     broadcast(liveJson)
   }

--- a/metro/src/app/madrid.ts
+++ b/metro/src/app/madrid.ts
@@ -28,7 +28,10 @@ export class Madrid {
         p.geometry.coordinates.reverse()[0][0]);
       const slots: Slot[] = []
       const station = new Station(p.properties.CODIGOANDEN.toString(), p.properties.DENOMINACION,
-        p.properties.NUMEROLINEAUSUARIO, position, path, p.properties.SENTIDO, slots)
+        p.properties.NUMEROLINEAUSUARIO, position, path, p.properties.SENTIDO, slots,
+        undefined,
+        p.properties.LONGITUDTRAMOANTERIOR ?? 0,
+        p.properties.VELOCIDADTRAMOANTERIOR ?? 0)
       this.paths.push(station)
     }
 

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -6,6 +6,7 @@ export interface MoveTrain {
   people?: number;
   capacity?: number;
   anden?: number;
+  travelMs?: number;
 }
 
 export interface PeopleInLinePlatforms {
@@ -43,6 +44,7 @@ export interface NewTrain {
   people?: number;
   capacity?: number;
   anden?: number;
+  travelMs?: number;
 }
 
 export interface RemoveTrain {

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -16,7 +16,7 @@ export class SimulationStateService {
   metroPeople = 0;
   trainsPeople = 0;
   timeMultiplier = 1;
-  paused = false;
+  paused = true;
   simLoad = 0;
   eventsPerTick = 0;
   queueSize = 0;
@@ -51,7 +51,7 @@ export class SimulationStateService {
           train.targetX = msg.x;
           train.targetY = msg.y;
           train.departedAt = performance.now();
-          train.travelMs = 135_000 * this.timeMultiplier;
+          train.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier;
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
           if (msg.anden    !== undefined) train.anden    = msg.anden;
@@ -67,7 +67,7 @@ export class SimulationStateService {
           existing.targetX = msg.x;
           existing.targetY = msg.y;
           existing.departedAt = performance.now();
-          existing.travelMs = 135_000 * this.timeMultiplier;
+          existing.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier;
           if (msg.people   !== undefined) existing.people   = msg.people;
           if (msg.capacity !== undefined) existing.capacity = msg.capacity;
           if (msg.anden    !== undefined) existing.anden    = msg.anden;

--- a/metro/src/app/station.ts
+++ b/metro/src/app/station.ts
@@ -12,9 +12,11 @@ export class Station {
   slots: Slot[];
   next: any;
   people: number;
+  longitudM: number;    // meters of the incoming segment (LONGITUDTRAMOANTERIOR)
+  velocidadKmh: number; // average speed km/h of the incoming segment (VELOCIDADTRAMOANTERIOR)
 
   constructor(id: string, name: string, line: string, position: Position, path: Position[], sentido: string,
-              slots: Slot[], next?: Station) {
+              slots: Slot[], next?: Station, longitudM = 0, velocidadKmh = 0) {
     this.id = id;
     this.name = name;
     this.line = line;
@@ -24,6 +26,8 @@ export class Station {
     this.empty = true;
     this.slots = slots;
     this.next = next;
-    this.people = 0
+    this.people = 0;
+    this.longitudM = longitudM;
+    this.velocidadKmh = velocidadKmh;
   }
 }

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -143,11 +143,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
               const last = path[path.length - 1];
               const prev = path[path.length - 2];
               train.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
-              // Scale travel time by actual segment arc length (reference: 50 cu ≈ median)
-              const segArcLen = segEnd - segStart;
-              if (segArcLen > 0) {
-                train.travelMs = train.travelMs * segArcLen / 50;
-              }
             }
           }
         }


### PR DESCRIPTION
## Summary

- **Simulador como fuente de verdad**: el simulador calcula el tiempo real de viaje de cada segmento usando los datos MITMA (`longitudtramoanterior / velocidadtramoanterior × 3600`) y lo envía en el mensaje `moveTrain` como `travelMs` en ms de reloj real
- **Frontend sin lógica de timing propia**: `simulation-state.service.ts` usa `msg.travelMs` directamente; ya no hay fórmulas propias en el frontend
- **Datos MITMA en Station**: se almacenan `longitudM` y `velocidadKmh` en el modelo de Station para uso futuro
- **Pausa garantizada al inicio**: `state.paused = true` por defecto para evitar que el frontend arranque antes de recibir el snapshot WebSocket

## Lo que NO está en este PR

El overload del SimClock a `speedFactor` alto (muchos eventos por tick) requiere una solución de rate-limiting en WebSocket broadcasts — se abordará en una rama separada.

## Test plan

- [ ] Verificar que los trenes animan en tiempos proporcionales a la distancia real del segmento
- [ ] Confirmar que al arrancar el simulador el frontend queda en estado PAUSED hasta pulsar Play
- [ ] Comprobar que al reconectar (reload) los trenes aparecen en su posición sin animación de viaje espuria
- [ ] Validar que tramos largos (L9B, L10a) tardan más que tramos cortos (L2 centro)