### PR TITLE
fix: trains move again and no longer overlap at platforms

### DIFF
--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -26,7 +26,7 @@ object Train {
 
       def travelMsForPath(p: Option[Path]): Long = p match {
         case Some(pp) if pp.features.velocidadtramoanterior > 0 && pp.features.longitudtramoanterior > 0 =>
-          (pp.features.longitudtramoanterior / pp.features.velocidadtramoanterior * 3600 * 1000).toLong
+          (pp.features.longitudtramoanterior / pp.features.velocidadtramoanterior * 3600).toLong
         case _ => FallbackTravelMs
       }
       def doorsMs():  Long = MinDoorsMs  + rng.nextLong(MaxDoorsMs  - MinDoorsMs)
@@ -77,7 +77,6 @@ object Train {
             } else {
               scribe.debug(s"Train $trainName departing from ${platform.get.path.name}")
               nextPlatform = Some(p)
-              platform.get ! LeavingPlatform
               val nextPp = findPlatformPath(p)
               lastTravelSimMs = travelMsForPath(nextPp)
               SimClock.scheduleIn(lastTravelSimMs) { () => selfRef ! TrainArrivedAtPlatform }
@@ -86,7 +85,9 @@ object Train {
 
           case TrainArrivedAtPlatform =>
             scribe.debug(s"Train $trainName arriving at ${nextPlatform.get.path.name}")
+            val prevPlatform = platform
             platform = nextPlatform
+            prevPlatform.get ! LeavingPlatform
             platform.get ! ArrivedAtPlatform(selfRef)
             people.foreach { case (_, person) => person ! ArrivedAtPlatformToPeople(platform.get) }
             val pp = findPlatformPath(platform.get)

--- a/metro-sim/src/main/scala/utils/WebSocket.scala
+++ b/metro-sim/src/main/scala/utils/WebSocket.scala
@@ -3,7 +3,6 @@ package utils
 import org.apache.pekko.NotUsed
 import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage}
 import org.apache.pekko.stream.OverflowStrategy
-import org.apache.pekko.stream.QueueOfferResult
 import org.apache.pekko.stream.scaladsl.{Flow, Sink, Source, SourceQueueWithComplete}
 
 object WebSocket {
@@ -23,7 +22,6 @@ object WebSocket {
   def listen(): Flow[Message, Message, NotUsed] = {
     val connId = java.util.UUID.randomUUID.toString
 
-    // Fix 2: parse incoming messages instead of dropping them
     val inbound: Sink[Message, Any] = Sink.foreach {
       case TextMessage.Strict(text) => commandHandler(text)
       case _                        => ()
@@ -33,7 +31,6 @@ object WebSocket {
       Source.queue[Message](4096, OverflowStrategy.dropHead)
 
     Flow.fromSinkAndSourceMat(inbound, outbound) { (_, queue) =>
-      // Fix 3: remove connection from list when client disconnects
       queue.watchCompletion().foreach { _ =>
         WebSocket.synchronized {
           connections = connections.filterNot(_._1 == connId)


### PR DESCRIPTION
## Summary

- **Trenes congelados**: error de conversión de unidades en `travelMsForPath`. Dividir `metros / (km/h)` da `h/1000`; multiplicar por `3600` da milisegundos. El código anterior multiplicaba por `3600 * 1000`, haciendo cada tramo ~1000× más largo (~55 horas sim, 5.5 h real) — el reloj avanzaba pero los trenes nunca llegaban.
- **Solapamiento en andenes**: `LeavingPlatform` se enviaba al reservar la plataforma siguiente, antes de que el frontend empezase a animar la salida. Otro tren podía llegar al andén mientras el primero seguía visualmente allí. Moviendo `LeavingPlatform` a `TrainArrivedAtPlatform`, la plataforma permanece bloqueada durante todo el viaje — los trenes esperan al final del túnel si el andén está ocupado.

## Test plan

- [ ] Arrancar el simulador y el frontend, reanudar la simulación
- [ ] Verificar que los trenes se mueven fluidamente entre estaciones
- [ ] Confirmar que nunca aparecen dos trenes en el mismo andén