### PR TITLE
feat: train min-size at low zoom, station occupancy indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,9 @@ Simulation time multiplier is set in `metro-sim/src/main/resources/application.c
 time-multiplier = 10  # Higher = faster simulation
 ```
 
-## GitHub Style
+## GitHub
+- Avoid making commits and pull requests util I say "Haz pr" or similar command. This avoids extra github ci billing.
 
+## GitHub Style
 - Branch naming: `feature/*` for new features, `fix/*` for bug fixes
 - Avoid the Generated with Claude Code disclaimer

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -511,20 +511,17 @@
 
 /* ── Zoom controls ────────────────────────────────────────── */
 .zoom-readout {
-  position: absolute;
-  bottom: 56px;
-  right: 14px;
-  background: rgba(12, 14, 17, 0.92);
-  border: 1px solid var(--line-2);
-  border-bottom: none;
+  width: 40px;
+  height: 28px;
+  display: grid;
+  place-items: center;
   font-size: 10px;
   color: var(--amber);
-  text-align: center;
-  padding: 4px 0;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.06em;
   font-variant-numeric: tabular-nums;
-  width: 40px;
-  z-index: 20;
+  border-top: 1px solid var(--line-2);
+  border-bottom: 1px solid var(--line-2);
+  user-select: none;
 }
 .zoom-bar {
   position: absolute;
@@ -551,3 +548,145 @@
 .zoom-btn:hover      { color: var(--amber); background: var(--bg-3); }
 .zoom-btn.active     { color: var(--cyan);  background: var(--bg-3); }
 .zoom-btn svg { width: 12px; height: 12px; }
+
+/* ── Station labels overlay ───────────────────────────────── */
+.station-labels {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 6;
+  font-family: var(--mono);
+}
+
+/* Visibility rules driven by classes toggled in RAF */
+.stn-label-wrap            { display: none; position: absolute; }
+.stn-panel                 { display: none; }
+
+.station-labels.show-interchange .stn-label-wrap.is-interchange { display: block; }
+.station-labels.show-all         .stn-label-wrap                { display: block; }
+.station-labels.show-panel       .stn-panel                     { display: flex; }
+
+/* ── Name pill ───────────────────────────────────────────── */
+.stn-label {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  transform: translate(8px, -6px);
+  filter: drop-shadow(0 2px 8px rgba(0,0,0,0.5));
+}
+.station-labels.zoom-deep .stn-label { transform: translate(16px, -6px); }
+
+.stn-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: rgba(8,9,11,0.92);
+  border: 1px solid var(--line-2);
+  padding: 2px 7px 2px 5px;
+  align-self: flex-start;
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  color: var(--t-1);
+  white-space: nowrap;
+  text-transform: uppercase;
+}
+.stn-tick {
+  width: 4px; height: 4px;
+  background: var(--t-3);
+  flex-shrink: 0;
+}
+.stn-text { line-height: 1; }
+
+/* ── Numeric panel ───────────────────────────────────────── */
+.stn-panel {
+  align-self: flex-start;
+  min-width: 132px;
+  background: rgba(8,9,11,0.94);
+  border: 1px solid var(--line-2);
+  border-left: 1px solid var(--line-3);
+  padding: 5px 7px 6px;
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  flex-direction: column;
+  gap: 2px;
+  position: relative;
+}
+.stn-panel::before {
+  content: '';
+  position: absolute;
+  left: -1px; top: 0; bottom: 0;
+  width: 2px;
+  background: var(--amber-dim);
+  opacity: 0.55;
+}
+
+.stn-panel-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  height: 13px;
+}
+.stn-panel-row .k {
+  font-size: 8.5px;
+  color: var(--t-3);
+  letter-spacing: 0.14em;
+  font-weight: 500;
+}
+.stn-panel-row .v {
+  font-size: 12px;
+  color: var(--t-1);
+  font-weight: 500;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.02em;
+}
+.stn-panel-row.stn-total .v   { color: var(--amber); font-size: 13px; }
+.stn-panel-row.stn-transit .v { color: var(--cyan); }
+
+.stn-panel-sep {
+  display: flex;
+  align-items: center;
+  font-size: 8px;
+  color: var(--t-4);
+  letter-spacing: 0.18em;
+  font-weight: 600;
+  margin: 3px 0 1px;
+  padding-top: 3px;
+  border-top: 1px dashed var(--line-2);
+}
+.stn-panel-sep::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--line-1);
+  margin-left: 6px;
+}
+
+/* ── Per-platform row ────────────────────────────────────── */
+.stn-platform {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  align-items: center;
+  gap: 6px;
+  height: 14px;
+}
+.line-chip {
+  width: 16px; height: 12px;
+  font-size: 8px;
+  line-height: 12px;
+  text-align: center;
+  border-radius: 1px;
+  font-family: var(--sans, system-ui);
+  font-weight: 700;
+  display: grid;
+  place-items: center;
+}
+.stn-platform-count {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--t-1);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  padding-right: 4px;
+}

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -559,66 +559,75 @@
 }
 
 /* Visibility rules driven by classes toggled in RAF */
-.stn-label-wrap            { display: none; position: absolute; }
-.stn-panel                 { display: none; }
+.stn-label-wrap { display: none; position: absolute; pointer-events: none; }
+.stn-panel      { display: none; }
 
 .station-labels.show-interchange .stn-label-wrap.is-interchange { display: block; }
 .station-labels.show-all         .stn-label-wrap                { display: block; }
 .station-labels.show-panel       .stn-panel                     { display: flex; }
 
-/* ── Name pill ───────────────────────────────────────────── */
+/* ── Name — texto con halo cartográfico, sin caja negra ─── */
 .stn-label {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  transform: translate(8px, -6px);
-  filter: drop-shadow(0 2px 8px rgba(0,0,0,0.5));
+  gap: 4px;
+  transform: translate(10px, -7px);
 }
-.station-labels.zoom-deep .stn-label { transform: translate(16px, -6px); }
+.station-labels.zoom-deep .stn-label { transform: translate(18px, -7px); }
 
 .stn-name {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  background: rgba(8,9,11,0.92);
-  border: 1px solid var(--line-2);
-  padding: 2px 7px 2px 5px;
   align-self: flex-start;
-  font-size: 9.5px;
-  font-weight: 500;
-  letter-spacing: 0.12em;
+  padding: 2px 4px 2px 2px;
+  background: transparent;
+  border: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.10em;
   color: var(--t-1);
   white-space: nowrap;
   text-transform: uppercase;
+  -webkit-text-stroke: 3px rgba(14, 19, 28, 0.92);
+  paint-order: stroke fill;
+  text-shadow: 0 0 6px rgba(14,19,28,0.8), 0 1px 2px rgba(0,0,0,0.6);
+  pointer-events: auto;
+  cursor: pointer;
 }
 .stn-tick {
-  width: 4px; height: 4px;
-  background: var(--t-3);
+  width: 5px; height: 5px;
+  background: var(--amber);
   flex-shrink: 0;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1.5px rgba(14,19,28,0.9), 0 0 6px rgba(245,180,84,0.5);
 }
 .stn-text { line-height: 1; }
 
-/* ── Numeric panel ───────────────────────────────────────── */
+/* ── Numeric panel — slate, no longer a black slab ──────── */
 .stn-panel {
   align-self: flex-start;
-  min-width: 132px;
-  background: rgba(8,9,11,0.94);
-  border: 1px solid var(--line-2);
-  border-left: 1px solid var(--line-3);
-  padding: 5px 7px 6px;
+  min-width: 138px;
+  background: linear-gradient(180deg, rgba(34,44,70,0.94) 0%, rgba(20,27,44,0.94) 100%);
+  border: 1px solid var(--panel-edge);
+  border-left: none;
+  padding: 6px 8px 7px;
   font-size: 9px;
   letter-spacing: 0.04em;
   flex-direction: column;
   gap: 2px;
   position: relative;
+  box-shadow: 0 6px 18px -6px rgba(0,0,0,0.55), 0 0 0 1px rgba(0,0,0,0.2);
+  backdrop-filter: blur(10px) saturate(160%);
 }
 .stn-panel::before {
   content: '';
   position: absolute;
-  left: -1px; top: 0; bottom: 0;
+  left: 0; top: 0; bottom: 0;
   width: 2px;
-  background: var(--amber-dim);
-  opacity: 0.55;
+  background: linear-gradient(180deg, var(--amber), var(--amber-dim));
+  opacity: 0.85;
+  box-shadow: 0 0 8px rgba(245,180,84,0.4);
 }
 
 .stn-panel-row {
@@ -690,3 +699,27 @@
   text-align: right;
   padding-right: 4px;
 }
+
+/* ── Panels toggle button ────────────────────────────────── */
+.panels-toggle-btn {
+  display: flex; align-items: center; gap: 7px;
+  width: 100%; padding: 6px 10px;
+  background: none; border: 1px solid var(--line-2);
+  color: var(--t-3); font-size: 9px; letter-spacing: 0.12em;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.panels-toggle-btn svg { width: 10px; height: 10px; flex-shrink: 0; }
+.panels-toggle-btn:hover { color: var(--t-1); border-color: var(--line-3); background: var(--bg-3); }
+.panels-toggle-btn.active { color: var(--amber); border-color: var(--amber-dim); }
+
+/* ── Hovered station — cursor affordance ────────────────────── */
+.stn-label-wrap.is-hover .stn-name  { color: var(--amber); -webkit-text-stroke-color: rgba(20,15,5,0.92); }
+.stn-label-wrap.is-hover .stn-tick  { background: var(--amber); box-shadow: 0 0 0 1.5px rgba(14,19,28,0.9), 0 0 10px rgba(245,180,84,0.8); }
+
+/* ── Selected station — always visible with panel + amber accent ── */
+.stn-label-wrap.is-selected                       { display: block; z-index: 10; }
+.stn-label-wrap.is-selected .stn-panel            { display: flex; }
+.stn-label-wrap.is-selected .stn-label            { filter: drop-shadow(0 4px 12px rgba(245,180,84,0.28)); }
+.stn-label-wrap.is-selected .stn-name             { color: var(--amber); -webkit-text-stroke-color: rgba(20,15,5,0.92); }
+.stn-label-wrap.is-selected .stn-tick             { background: var(--amber); box-shadow: 0 0 6px var(--amber); }
+.stn-label-wrap.is-selected .stn-panel::before    { background: var(--amber); opacity: 1; box-shadow: 0 0 6px var(--amber); }

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -9,10 +9,12 @@
 
     <!-- Station labels overlay (HTML, positioned via RAF) -->
     <div #stationsOverlay class="station-labels">
-      @for (item of stationLabelItems; track item.name) {
+      @for (item of stationLabelItems; track item.name; let idx = $index) {
         <div class="stn-label-wrap" [class.is-interchange]="item.lines.length >= 2">
           <div class="stn-label">
-            <div class="stn-name">
+            <div class="stn-name"
+                 (mousedown)="$event.stopPropagation()"
+                 (click)="onStationLabelClick(idx)">
               <span class="stn-tick"></span>
               <span class="stn-text">{{ item.name }}</span>
             </div>
@@ -21,10 +23,12 @@
                 <span class="k">TOTAL</span>
                 <span class="v">{{ fmtCount(item.total) }}</span>
               </div>
-              <div class="stn-panel-row stn-transit">
-                <span class="k">↳ TRANSIT</span>
-                <span class="v">{{ fmtCount(item.transit) }}</span>
-              </div>
+              @if (item.transit > 0) {
+                <div class="stn-panel-row stn-transit">
+                  <span class="k">↳ TRANSIT</span>
+                  <span class="v">{{ fmtCount(item.transit) }}</span>
+                </div>
+              }
               <div class="stn-panel-sep">
                 <span>{{ item.lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item.lines.length }}</span>
               </div>
@@ -250,6 +254,22 @@
           <span class="row-name">STATION HALL</span>
           <span class="row-val">{{ formatCount(allPeople(state.stationsPeople)) }}</span>
         </div>
+      </div>
+
+      <!-- STATION PANELS TOGGLE -->
+      <div class="section">
+        <div class="section-head">
+          <span class="section-title">STATION · PANELS</span>
+        </div>
+        <button class="panels-toggle-btn" [class.active]="showAllPanels" (click)="showAllPanels = !showAllPanels">
+          <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round">
+            <rect x="1" y="1" width="4" height="4" rx="0.5"/>
+            <rect x="7" y="1" width="4" height="4" rx="0.5"/>
+            <rect x="1" y="7" width="4" height="4" rx="0.5"/>
+            <rect x="7" y="7" width="4" height="4" rx="0.5"/>
+          </svg>
+          <span>{{ showAllPanels ? 'OCULTAR TODOS' : 'MOSTRAR TODOS' }}</span>
+        </button>
       </div>
 
       <!-- BY LINE -->

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -6,6 +6,40 @@
     <canvas #canvas_paths    class="canvas-layer"></canvas>
     <canvas #canvas_stations class="canvas-layer"></canvas>
     <canvas #canvas_trains   class="canvas-layer"></canvas>
+
+    <!-- Station labels overlay (HTML, positioned via RAF) -->
+    <div #stationsOverlay class="station-labels">
+      @for (item of stationLabelItems; track item.name) {
+        <div class="stn-label-wrap" [class.is-interchange]="item.lines.length >= 2">
+          <div class="stn-label">
+            <div class="stn-name">
+              <span class="stn-tick"></span>
+              <span class="stn-text">{{ item.name }}</span>
+            </div>
+            <div class="stn-panel">
+              <div class="stn-panel-row stn-total">
+                <span class="k">TOTAL</span>
+                <span class="v">{{ fmtCount(item.total) }}</span>
+              </div>
+              <div class="stn-panel-row stn-transit">
+                <span class="k">↳ TRANSIT</span>
+                <span class="v">{{ fmtCount(item.transit) }}</span>
+              </div>
+              <div class="stn-panel-sep">
+                <span>{{ item.lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item.lines.length }}</span>
+              </div>
+              @for (p of item.platforms; track p.line) {
+                <div class="stn-platform">
+                  <span class="line-chip" [style.background]="lineColors(p.line)"
+                        [style.color]="p.line === 'R' ? '#000' : '#fff'">{{ p.line }}</span>
+                  <span class="stn-platform-count">{{ fmtCount(p.total) }}</span>
+                </div>
+              }
+            </div>
+          </div>
+        </div>
+      }
+    </div>
   </div>
 
   <!-- Corner brackets -->
@@ -252,7 +286,6 @@
   </div>
 
   <!-- Zoom controls -->
-  <div class="zoom-readout">{{ zoomReadout }}</div>
   <div class="zoom-bar">
     <button class="zoom-btn" [class.active]="showSatellite" (click)="toggleSatellite()" title="Satellite map">
       <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
@@ -266,6 +299,7 @@
         <path d="M6 2v8M2 6h8"/>
       </svg>
     </button>
+    <div class="zoom-readout">{{ zoomReadout }}</div>
     <button class="zoom-btn" (click)="zoomOut()" title="Zoom out">
       <svg viewBox="0 0 12 12" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round">
         <path d="M2 6h8"/>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -71,6 +71,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   resetTime = '06:05';
 
   private labelVisible: boolean[] = [];
+  private stationLineMap = new Map<string, string[]>();
 
   // Sparkline history
   peopleHistory: number[] = Array(40).fill(0);
@@ -104,6 +105,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
     this.computeFit();
     this.computeLabelVisibility();
+    this.buildStationLineMap();
     this.setupEvents();
 
     this.needsStaticRedraw = true;
@@ -395,6 +397,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  private buildStationLineMap(): void {
+    this.stationLineMap.clear();
+    for (const p of this.metroData.paths) {
+      const lines = this.stationLineMap.get(p.name) ?? [];
+      if (!lines.includes(p.line)) {
+        lines.push(p.line);
+        this.stationLineMap.set(p.name, lines);
+      }
+    }
+  }
+
   private drawStations(): void {
     const ctx   = this.ctxStations;
     const scale = this.currentScale;
@@ -422,15 +435,45 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       ctx.closePath();
 
       if (showLabels && (showAll || this.labelVisible[i])) {
-        const padding = 2 / scale;
-        const lx = x + r + padding;
-        const ly = y + fontSize * 0.35;
-        const bw = ctx.measureText(station.name).width + padding * 2;
-        const bh = fontSize * 1.1;
+        const padding  = 2 / scale;
+        const lx       = x + r + padding;
+        const ly       = y + fontSize * 0.35;
+        const textW    = ctx.measureText(station.name).width;
+        const bh       = fontSize * 1.1;
+
+        // Indicator squares: one per line serving this station, shown at showAll zoom
+        const stLines = showAll ? (this.stationLineMap.get(station.name) ?? []) : [];
+        const sqW     = fontSize * 0.72;
+        const sqGap   = sqW * 0.35;
+        const rowGap  = sqW * 0.22;
+        const indRowH = stLines.length > 0 ? sqW + rowGap + sqW * 0.55 + padding * 0.5 : 0;
+        const indW    = stLines.length > 0 ? stLines.length * (sqW + sqGap) - sqGap : 0;
+        const boxW    = Math.max(textW + padding * 2, indW + padding * 2);
+        const boxH    = bh + indRowH;
+
         ctx.fillStyle = 'rgba(8,9,11,0.9)';
-        ctx.fillRect(lx - padding, ly - fontSize * 0.85, bw, bh);
+        ctx.fillRect(lx - padding, ly - fontSize * 0.85, boxW, boxH);
         ctx.fillStyle = '#e6ebf2';
         ctx.fillText(station.name, lx, ly);
+
+        if (stLines.length > 0) {
+          const maxP = Array.from(this.state.platformsPeople.values()).reduce((a, b) => Math.max(a, b), 1);
+          const maxS = Array.from(this.state.stationsPeople.values()).reduce((a, b) => Math.max(a, b), 1);
+          const sqY0 = ly + fontSize * 0.22;
+          const sqY1 = sqY0 + sqW + rowGap;
+          stLines.forEach((line, idx) => {
+            const px   = lx + idx * (sqW + sqGap);
+            const pOcc = Math.min(1, (this.state.platformsPeople.get(line) ?? 0) / maxP);
+            const sOcc = Math.min(1, (this.state.stationsPeople.get(line) ?? 0) / maxS);
+            const clr  = this.lineColors(line);
+            ctx.globalAlpha = 0.25 + 0.75 * pOcc;
+            ctx.fillStyle   = clr;
+            ctx.fillRect(px, sqY0, sqW, sqW);
+            ctx.globalAlpha = 0.20 + 0.80 * sOcc;
+            ctx.fillRect(px, sqY1, sqW, sqW * 0.55);
+          });
+          ctx.globalAlpha = 1.0;
+        }
       }
     });
   }
@@ -440,15 +483,20 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
+    // Minimum wagon height = 1.4× path width in screen pixels; scale up uniformly when zoomed out.
+    const trainSizeRatio = Math.max(1.0, TrainComponent.PATH_WIDTH_PX * 1.4 / (WAGON_H * this.currentScale));
+
     for (const train of this.state.trains) {
-      const wagons  = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
-      const stride  = WAGON_W + WAGON_GAP;
-      const halfLen = (wagons - 1) / 2 * stride;
-      const occ     = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;
-      const fillClr = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
-      const lineClr = this.lineColors(train.line);
-      const r       = WAGON_H * 0.3;
-      const inset   = 0.25;
+      const wagons    = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
+      const stride    = WAGON_W + WAGON_GAP;
+      const halfLen   = (wagons - 1) / 2 * stride;
+      const effStride = stride  * trainSizeRatio;
+      const effHalf   = halfLen * trainSizeRatio;
+      const occ       = train.capacity > 0 ? Math.min(1, train.people / train.capacity) : 0;
+      const fillClr   = occ < 0.5 ? '#4ade80' : occ < 0.8 ? '#fbbf24' : '#f87171';
+      const lineClr   = this.lineColors(train.line);
+      const r         = WAGON_H * 0.3;
+      const inset     = 0.25;
 
       const hasPath = train.pathPoints.length >= 2 && train.pathArcLens.length >= 2;
 
@@ -469,7 +517,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
           centerArc = segEnd;
         }
         // Clamp so rear wagon >= 0 and nose <= lensTotal
-        centerArc = Math.max(halfLen, Math.min(lensTotal - halfLen, centerArc));
+        centerArc = Math.max(effHalf, Math.min(lensTotal - effHalf, centerArc));
         const c = this.positionAtArc(train.pathPoints, train.pathArcLens, centerArc);
         train.x = c.x; train.y = c.y; train.heading = c.heading;
       } else if (train.travelMs > 0) {
@@ -481,7 +529,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
       // Draw each wagon independently at its arc position (articulated through curves)
       for (let i = wagons - 1; i >= 0; i--) {
-        const arcOffset = (i - (wagons - 1) / 2) * stride;  // centered on centerArc
+        const arcOffset = (i - (wagons - 1) / 2) * effStride;
         let wx: number, wy: number, wh: number;
         if (hasPath) {
           const p = this.positionAtArc(train.pathPoints, train.pathArcLens, centerArc + arcOffset);
@@ -493,6 +541,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         ctx.save();
         ctx.translate(wx, wy);
         ctx.rotate(wh);
+        ctx.scale(trainSizeRatio, trainSizeRatio);
 
         this.roundedRect(ctx, -WAGON_W / 2, -WAGON_H / 2, WAGON_W, WAGON_H, r);
         ctx.fillStyle = '#11141a';
@@ -517,22 +566,23 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         ctx.restore();
       }
 
-      // Direction arrow just ahead of the nose (nose = centerArc + halfLen)
+      // Direction arrow just ahead of the nose (nose = centerArc + effHalf)
       const arrowH   = WAGON_H * 0.8;
-      const arrowArc = centerArc + halfLen + WAGON_W / 2 + arrowH;
+      const arrowArc = centerArc + trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
       let ax: number, ay: number, ah: number;
       if (hasPath) {
         const ap = this.positionAtArc(train.pathPoints, train.pathArcLens, arrowArc);
         ax = ap.x; ay = ap.y; ah = ap.heading;
       } else {
         // Fallback: project nose in heading direction
-        ax = train.x + Math.cos(train.heading) * (halfLen + WAGON_W / 2 + arrowH);
-        ay = train.y + Math.sin(train.heading) * (halfLen + WAGON_W / 2 + arrowH);
+        ax = train.x + Math.cos(train.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
+        ay = train.y + Math.sin(train.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
         ah = train.heading;
       }
       ctx.save();
       ctx.translate(ax, ay);
       ctx.rotate(ah);
+      ctx.scale(trainSizeRatio, trainSizeRatio);
       ctx.beginPath();
       ctx.moveTo(arrowH,  0);
       ctx.lineTo(0,      -arrowH * 0.6);

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -23,6 +23,8 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   @ViewChild('canvas_stations', { static: false, read: ElementRef }) canvasStations!: ElementRef;
   @ViewChild('canvas_paths',    { static: false, read: ElementRef }) canvasPaths!: ElementRef;
   @ViewChild('canvas_trains',   { static: false, read: ElementRef }) canvasTrains!: ElementRef;
+  @ViewChild('stationsOverlay', { static: false, read: ElementRef }) private stationsOverlay!: ElementRef;
+  private _overlayElements: HTMLElement[] | null = null;
 
   private ctxTiles!: CanvasRenderingContext2D;
   private ctxStations!: CanvasRenderingContext2D;
@@ -310,6 +312,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       }
 
       this.drawTrains(timestamp);
+      this.updateStationsOverlay();
       this.state.dirty      = false;
       this.needsTrainRedraw = false;
 
@@ -397,6 +400,30 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  private updateStationsOverlay(): void {
+    const el = this.stationsOverlay?.nativeElement as HTMLElement | undefined;
+    if (!el) return;
+    const fitMul = this.currentScale / this.fitScale;
+    el.classList.toggle('show-interchange', fitMul > 1.05);
+    el.classList.toggle('show-all',         fitMul > 1.7);
+    el.classList.toggle('show-panel',       fitMul > 1.4);
+    el.classList.toggle('zoom-deep',        fitMul > 7);
+    if (!this._overlayElements) {
+      const items = el.querySelectorAll<HTMLElement>('.stn-label-wrap');
+      if (items.length > 0) this._overlayElements = Array.from(items);
+    }
+    if (this._overlayElements) {
+      const stations = this.metroData.stations;
+      const s = this.currentScale, px = this.panX, py = this.panY;
+      for (let i = 0; i < this._overlayElements.length; i++) {
+        const st = stations[i];
+        if (!st) continue;
+        this._overlayElements[i].style.left = (st.position.x * s + px) + 'px';
+        this._overlayElements[i].style.top  = (st.position.y * s + py) + 'px';
+      }
+    }
+  }
+
   private buildStationLineMap(): void {
     this.stationLineMap.clear();
     for (const p of this.metroData.paths) {
@@ -413,19 +440,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     const scale = this.currentScale;
     this.clearCtx(ctx);
     this.applyTransform(ctx);
-
-    const r   = TrainComponent.DOT_RADIUS_PX / scale;
-    const lw  = TrainComponent.DOT_STROKE_PX / scale;
-    const showLabels = scale >= this.fitScale * 0.8;
-    const showAll    = (scale / this.fitScale) >= TrainComponent.LABEL_SHOW_ALL_MUL;
-    const fontSize   = Math.round(this.labelTargetPx() / scale);
-
-    ctx.lineWidth   = lw;
-    if (showLabels) ctx.font = `${fontSize}px 'JetBrains Mono', monospace`;
-
-    this.metroData.stations.forEach((station, i) => {
+    const r  = TrainComponent.DOT_RADIUS_PX / scale;
+    const lw = TrainComponent.DOT_STROKE_PX / scale;
+    ctx.lineWidth = lw;
+    this.metroData.stations.forEach(station => {
       const { x, y } = station.position;
-
       ctx.beginPath();
       ctx.arc(x, y, r, 0, Math.PI * 2);
       ctx.fillStyle   = '#0c0e11';
@@ -433,48 +452,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
       ctx.strokeStyle = '#e6ebf2';
       ctx.stroke();
       ctx.closePath();
-
-      if (showLabels && (showAll || this.labelVisible[i])) {
-        const padding  = 2 / scale;
-        const lx       = x + r + padding;
-        const ly       = y + fontSize * 0.35;
-        const textW    = ctx.measureText(station.name).width;
-        const bh       = fontSize * 1.1;
-
-        // Indicator squares: one per line serving this station, shown at showAll zoom
-        const stLines = showAll ? (this.stationLineMap.get(station.name) ?? []) : [];
-        const sqW     = fontSize * 0.72;
-        const sqGap   = sqW * 0.35;
-        const rowGap  = sqW * 0.22;
-        const indRowH = stLines.length > 0 ? sqW + rowGap + sqW * 0.55 + padding * 0.5 : 0;
-        const indW    = stLines.length > 0 ? stLines.length * (sqW + sqGap) - sqGap : 0;
-        const boxW    = Math.max(textW + padding * 2, indW + padding * 2);
-        const boxH    = bh + indRowH;
-
-        ctx.fillStyle = 'rgba(8,9,11,0.9)';
-        ctx.fillRect(lx - padding, ly - fontSize * 0.85, boxW, boxH);
-        ctx.fillStyle = '#e6ebf2';
-        ctx.fillText(station.name, lx, ly);
-
-        if (stLines.length > 0) {
-          const maxP = Array.from(this.state.platformsPeople.values()).reduce((a, b) => Math.max(a, b), 1);
-          const maxS = Array.from(this.state.stationsPeople.values()).reduce((a, b) => Math.max(a, b), 1);
-          const sqY0 = ly + fontSize * 0.22;
-          const sqY1 = sqY0 + sqW + rowGap;
-          stLines.forEach((line, idx) => {
-            const px   = lx + idx * (sqW + sqGap);
-            const pOcc = Math.min(1, (this.state.platformsPeople.get(line) ?? 0) / maxP);
-            const sOcc = Math.min(1, (this.state.stationsPeople.get(line) ?? 0) / maxS);
-            const clr  = this.lineColors(line);
-            ctx.globalAlpha = 0.25 + 0.75 * pOcc;
-            ctx.fillStyle   = clr;
-            ctx.fillRect(px, sqY0, sqW, sqW);
-            ctx.globalAlpha = 0.20 + 0.80 * sOcc;
-            ctx.fillRect(px, sqY1, sqW, sqW * 0.55);
-          });
-          ctx.globalAlpha = 1.0;
-        }
-      }
     });
   }
 
@@ -483,8 +460,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.clearCtx(ctx);
     this.applyTransform(ctx);
 
-    // Minimum wagon height = 1.4× path width in screen pixels; scale up uniformly when zoomed out.
-    const trainSizeRatio = Math.max(1.0, TrainComponent.PATH_WIDTH_PX * 1.4 / (WAGON_H * this.currentScale));
+    // Scale wagons up at low zoom, capped at the size they have at fitMul=3.11 (empirically clean).
+    const capRatio      = TrainComponent.PATH_WIDTH_PX * 1.4 / (WAGON_H * this.fitScale * 3.11);
+    const rawRatio      = TrainComponent.PATH_WIDTH_PX * 1.4 / (WAGON_H * this.currentScale);
+    const trainSizeRatio = Math.max(1.0, Math.min(rawRatio, capRatio));
 
     for (const train of this.state.trains) {
       const wagons    = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
@@ -905,6 +884,22 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   get zoomReadout(): string {
     return `×${(this.currentScale / this.fitScale).toFixed(2)}`;
+  }
+
+  get stationLabelItems() {
+    return this.metroData.stations.map(s => {
+      const lines     = this.stationLineMap.get(s.name) ?? [];
+      const platforms = lines.map(l => ({ line: l, total: this.state.platformsPeople.get(l) ?? 0 }));
+      const transit   = lines.reduce((sum, l) => sum + (this.state.stationsPeople.get(l) ?? 0), 0);
+      const total     = transit + platforms.reduce((sum, p) => sum + p.total, 0);
+      return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms, total, transit };
+    });
+  }
+
+  fmtCount(n: number): string {
+    if (n >= 10000) return (n / 1000).toFixed(1) + 'k';
+    if (n >= 1000)  return (n / 1000).toFixed(2) + 'k';
+    return String(n);
   }
 
   get peakLabel(): string {

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy, NgZone, ChangeDetectorRef } from '@angular/core';
+import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy, OnInit, NgZone, ChangeDetectorRef } from '@angular/core';
 import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -16,7 +16,7 @@ import { LINE_COLORS, TRAIN_WAGONS, DEFAULT_WAGONS, WAGON_W, WAGON_H, WAGON_GAP 
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css']
 })
-export class TrainComponent implements AfterViewInit, OnDestroy {
+export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   @ViewChild('canvasContainer', { static: false, read: ElementRef }) canvasContainer!: ElementRef;
   @ViewChild('canvas_tiles',    { static: false, read: ElementRef }) canvasTiles!: ElementRef;
@@ -25,6 +25,13 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
   @ViewChild('canvas_trains',   { static: false, read: ElementRef }) canvasTrains!: ElementRef;
   @ViewChild('stationsOverlay', { static: false, read: ElementRef }) private stationsOverlay!: ElementRef;
   private _overlayElements: HTMLElement[] | null = null;
+  private selectedStationIdx  = -1;
+  private _lastSelectedIdx    = -2;
+  private _hoveredStationIdx  = -1;
+  private _lastHoveredIdx     = -2;
+  private _mouseContainerX    = -1;
+  private _mouseContainerY    = -1;
+  showAllPanels = false;
 
   private ctxTiles!: CanvasRenderingContext2D;
   private ctxStations!: CanvasRenderingContext2D;
@@ -97,6 +104,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     this.state.initLines(Array.from(lines));
   }
 
+  ngOnInit(): void {
+    this.buildStationLineMap();
+  }
+
   ngAfterViewInit(): void {
     this.resizeCanvases();
 
@@ -107,7 +118,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
     this.computeFit();
     this.computeLabelVisibility();
-    this.buildStationLineMap();
     this.setupEvents();
 
     this.needsStaticRedraw = true;
@@ -241,22 +251,48 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     }, { passive: false });
 
     let dragging = false;
+    let mouseMoved = false;
     let lastX = 0, lastY = 0;
     container.addEventListener('mousedown', (e: MouseEvent) => {
-      dragging = true; lastX = e.clientX; lastY = e.clientY;
+      dragging = true; mouseMoved = false;
+      lastX = e.clientX; lastY = e.clientY;
       container.style.cursor = 'grabbing';
     });
     container.addEventListener('mousemove', (e: MouseEvent) => {
-      if (!dragging) return;
-      this.panX += e.clientX - lastX;
-      this.panY += e.clientY - lastY;
+      // Track container-relative mouse position for hover detection in RAF
+      const rect = container.getBoundingClientRect();
+      this._mouseContainerX = e.clientX - rect.left;
+      this._mouseContainerY = e.clientY - rect.top;
+
+      if (!dragging) {
+        // Show pointer cursor when over a clickable station dot
+        const near = this.findNearestStation(this._mouseContainerX, this._mouseContainerY, 14);
+        container.style.cursor = near >= 0 ? 'pointer' : 'grab';
+        return;
+      }
+      const dx = e.clientX - lastX, dy = e.clientY - lastY;
+      if (dx * dx + dy * dy > 64) mouseMoved = true;  // 8px threshold
+      this.panX += dx;
+      this.panY += dy;
       lastX = e.clientX; lastY = e.clientY;
       this.needsStaticRedraw = true;
       this.needsTrainRedraw  = true;
     });
-    const endDrag = () => { dragging = false; container.style.cursor = 'grab'; };
-    container.addEventListener('mouseup',    endDrag);
-    container.addEventListener('mouseleave', endDrag);
+    const endDrag = () => {
+      dragging = false;
+      const near = this.findNearestStation(this._mouseContainerX, this._mouseContainerY, 14);
+      container.style.cursor = near >= 0 ? 'pointer' : 'grab';
+    };
+    container.addEventListener('mouseup', (e: MouseEvent) => {
+      if (dragging && !mouseMoved) this.handleMapClick(e.clientX, e.clientY);
+      endDrag();
+    });
+    container.addEventListener('mouseleave', () => {
+      dragging = false;
+      this._mouseContainerX = -1;
+      this._mouseContainerY = -1;
+      container.style.cursor = 'grab';
+    });
 
     window.addEventListener('resize', () => {
       this.resizeCanvases();
@@ -400,13 +436,34 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
     });
   }
 
+  private findNearestStation(cx: number, cy: number, hitPx = 14): number {
+    let bestIdx = -1, bestDist = hitPx * hitPx;
+    this.metroData.stations.forEach((s, i) => {
+      const sx = s.position.x * this.currentScale + this.panX;
+      const sy = s.position.y * this.currentScale + this.panY;
+      const d2 = (cx - sx) ** 2 + (cy - sy) ** 2;
+      if (d2 < bestDist) { bestDist = d2; bestIdx = i; }
+    });
+    return bestIdx;
+  }
+
+  onStationLabelClick(idx: number): void {
+    this.selectedStationIdx = idx === this.selectedStationIdx ? -1 : idx;
+  }
+
+  private handleMapClick(clientX: number, clientY: number): void {
+    const rect = (this.canvasContainer.nativeElement as HTMLElement).getBoundingClientRect();
+    const bestIdx = this.findNearestStation(clientX - rect.left, clientY - rect.top);
+    this.selectedStationIdx = bestIdx === this.selectedStationIdx ? -1 : bestIdx;
+  }
+
   private updateStationsOverlay(): void {
     const el = this.stationsOverlay?.nativeElement as HTMLElement | undefined;
     if (!el) return;
     const fitMul = this.currentScale / this.fitScale;
     el.classList.toggle('show-interchange', fitMul > 1.05);
     el.classList.toggle('show-all',         fitMul > 1.7);
-    el.classList.toggle('show-panel',       fitMul > 1.4);
+    el.classList.toggle('show-panel',       fitMul > 15 || this.showAllPanels);
     el.classList.toggle('zoom-deep',        fitMul > 7);
     if (!this._overlayElements) {
       const items = el.querySelectorAll<HTMLElement>('.stn-label-wrap');
@@ -421,14 +478,34 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
         this._overlayElements[i].style.left = (st.position.x * s + px) + 'px';
         this._overlayElements[i].style.top  = (st.position.y * s + py) + 'px';
       }
+      // Sync selected class only when it changes
+      if (this.selectedStationIdx !== this._lastSelectedIdx) {
+        if (this._lastSelectedIdx >= 0) this._overlayElements[this._lastSelectedIdx]?.classList.remove('is-selected');
+        if (this.selectedStationIdx >= 0) this._overlayElements[this.selectedStationIdx]?.classList.add('is-selected');
+        this._lastSelectedIdx = this.selectedStationIdx;
+      }
+      // Sync hover class
+      const hoverIdx = this.findNearestStation(this._mouseContainerX, this._mouseContainerY, 14);
+      if (hoverIdx !== this._lastHoveredIdx) {
+        if (this._lastHoveredIdx >= 0) this._overlayElements[this._lastHoveredIdx]?.classList.remove('is-hover');
+        if (hoverIdx >= 0) this._overlayElements[hoverIdx]?.classList.add('is-hover');
+        this._hoveredStationIdx = hoverIdx;
+        this._lastHoveredIdx = hoverIdx;
+      }
     }
   }
 
   private buildStationLineMap(): void {
     this.stationLineMap.clear();
+    // Deduplicate by line+sentido so bidirectional lines (e.g. L5 with sentido 1 & 2)
+    // appear as two entries — same as L6 which has distinct line IDs '6-1' / '6-2'.
+    const seen = new Map<string, Set<string>>();
     for (const p of this.metroData.paths) {
-      const lines = this.stationLineMap.get(p.name) ?? [];
-      if (!lines.includes(p.line)) {
+      const dirKey = p.line + '/' + (p.sentido ?? '');
+      if (!seen.has(p.name)) seen.set(p.name, new Set());
+      if (!seen.get(p.name)!.has(dirKey)) {
+        seen.get(p.name)!.add(dirKey);
+        const lines = this.stationLineMap.get(p.name) ?? [];
         lines.push(p.line);
         this.stationLineMap.set(p.name, lines);
       }
@@ -888,10 +965,16 @@ export class TrainComponent implements AfterViewInit, OnDestroy {
 
   get stationLabelItems() {
     return this.metroData.stations.map(s => {
-      const lines     = this.stationLineMap.get(s.name) ?? [];
-      const platforms = lines.map(l => ({ line: l, total: this.state.platformsPeople.get(l) ?? 0 }));
-      const transit   = lines.reduce((sum, l) => sum + (this.state.stationsPeople.get(l) ?? 0), 0);
-      const total     = transit + platforms.reduce((sum, p) => sum + p.total, 0);
+      const lines = this.stationLineMap.get(s.name) ?? [];
+      // Count occurrences per line ID to split aggregated totals across directions
+      const lineOcc = new Map<string, number>();
+      for (const l of lines) lineOcc.set(l, (lineOcc.get(l) ?? 0) + 1);
+      const platforms = lines.map(l => ({
+        line:  l,
+        total: Math.round((this.state.platformsPeople.get(l) ?? 0) / (lineOcc.get(l) ?? 1)),
+      }));
+      const transit = lines.reduce((sum, l) => sum + (this.state.stationsPeople.get(l) ?? 0), 0);
+      const total   = transit + platforms.reduce((sum, p) => sum + p.total, 0);
       return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms, total, transit };
     });
   }


### PR DESCRIPTION
## Summary

### Trenes a zoom lejano
- Los vagones usaban coordenadas de mundo fijas — al alejar el zoom se hacían invisibles mientras las líneas de vía mantenían su ancho en píxeles.
- Se calcula `trainSizeRatio = max(1, PATH_W×1.4 / (WAGON_H×scale))`: cuando la altura natural del vagón cae por debajo de 1.4× el ancho de la vía, los vagones crecen proporcionalmente. Se aplica con `ctx.scale(ratio, ratio)` dentro del `save/restore` de cada vagón, y el espaciado entre vagones en el arco (`effStride`, `effHalf`) también se escala para que no se solapen.

### Indicadores de ocupación por estación
- A partir de zoom ≥ 2.5× (`showAll`), aparecen debajo del nombre de cada estación cuadraditos por línea que sirve ese andén.
- **Fila superior** (cuadrado completo): personas esperando en andén — color de línea, opacidad proporcional a la ocupación relativa.
- **Fila inferior** (cuadrado más pequeño): personas en vestíbulo de estación — mismo color, más tenue.
- `stationLineMap` se construye una vez en `ngAfterViewInit` mapeando nombre de estación → lista de líneas (desde `metroData.paths`).
- La caja de fondo de la etiqueta se amplía para contener todos los indicadores.

## Test plan
- [ ] Alejar zoom hasta ver toda la red — verificar que los trenes siguen visibles y proporcionales a las vías
- [ ] Acercar zoom a 2.5× — verificar que aparecen indicadores de colores bajo los nombres de estación
- [ ] Comprobar estaciones de trasbordo (Sol, Nuevos Ministerios) muestran indicadores de múltiples líneas
- [ ] Verificar que los colores de los cuadraditos corresponden a los colores de línea