### PR TITLE
fix: correct passenger spawn rate and per-platform/station occupancy

### DIFF
--- a/metro-sim/src/main/scala/Line.scala
+++ b/metro-sim/src/main/scala/Line.scala
@@ -24,6 +24,14 @@ object Line {
           val stationPeople = stations.values.sum
           ui ! PeopleInLinePlatforms(lineId, platformPeople)
           ui ! PeopleInLineStations(lineId, stationPeople)
+          platforms.foreach { case (platformId, count) =>
+            platformId.split("_").last.toIntOption.foreach { anden =>
+              ui ! PeopleInSpecificPlatform(anden, count)
+            }
+          }
+          stations.foreach { case (stationId, count) =>
+            ui ! PeopleInSpecificStation(stationId, count)
+          }
           Behaviors.same
 
         case PeopleInPlatform(platformId, people) =>

--- a/metro-sim/src/main/scala/Simulator.scala
+++ b/metro-sim/src/main/scala/Simulator.scala
@@ -20,6 +20,7 @@ object Simulator {
     16 -> 6, 17 -> 7, 18 -> 8, 19 -> 8, 20 -> 7,
     21 -> 5, 22 -> 3, 23 -> 2
   )
+  private val HourDistributionSum: Double = HourDistribution.values.sum
 
   private val TimeStepMs = 10_000L
 
@@ -109,11 +110,11 @@ object Simulator {
                 .values.flatten
               dailyEntrance: Double  = startStationId.entrance / 30.0
               hourMultiplier: Double = HourDistribution.getOrElse(hourKey, 0.0)
-              peopleCount: Double    = (dailyEntrance * TimeStepMs / 86_400_000.0 +
-                startNode.partialPerson) * hourMultiplier
+              baseCount: Double      = dailyEntrance * hourMultiplier / HourDistributionSum * TimeStepMs / 3_600_000.0
+              peopleCount: Double    = baseCount + startNode.partialPerson
               integerPart: Int    = peopleCount.toInt
               floatPart:   Double = peopleCount - integerPart
-              _ = if (floatPart > 0) startNode.setPartialPerson(floatPart)
+              _ = startNode.setPartialPerson(floatPart)
               _ <- 1 to integerPart
               destinationNode = pickDestination(startNode, hourKey)
               journey: Option[metroGraph.Path] = startNode shortestPathTo destinationNode

--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -53,6 +53,16 @@ object UI {
             s"""{"message": "peopleInLineStations", "line": "$lineId", "people": $people}""")
           Behaviors.same
 
+        case PeopleInSpecificPlatform(anden, people) =>
+          WebSocket.sendStat(s"peopleInPlatform:$anden",
+            s"""{"message": "peopleInPlatform", "anden": $anden, "people": $people}""")
+          Behaviors.same
+
+        case PeopleInSpecificStation(stationId, people) =>
+          WebSocket.sendStat(s"peopleInStation:$stationId",
+            s"""{"message": "peopleInStation", "stationId": "$stationId", "people": $people}""")
+          Behaviors.same
+
         case PlatformOvercrowded(platformId, people) =>
           scribe.debug(s"There are $people people in platform $platformId")
           WebSocket.sendText(

--- a/metro-sim/src/main/scala/messages/Messages.scala
+++ b/metro-sim/src/main/scala/messages/Messages.scala
@@ -63,6 +63,8 @@ object Messages {
   case class PeopleInTrain(trainId: String, people: Int) extends UIMessage
   case class PeopleInLinePlatforms(lineId: String, people: Int) extends UIMessage
   case class PeopleInLineStations(lineId: String, people: Int) extends UIMessage
+  case class PeopleInSpecificPlatform(anden: Int, people: Int) extends UIMessage
+  case class PeopleInSpecificStation(stationId: String, people: Int) extends UIMessage
   case class PlatformOvercrowded(platformId: String, people: Int) extends UIMessage
   case class StationOvercrowded(stationId: String, people: Int) extends UIMessage
   case class PeopleInMetro(people: Int) extends UIMessage

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -57,6 +57,18 @@ export interface TimeMultiplier {
   multiplier: number;
 }
 
+export interface PeopleInPlatform {
+  message: 'peopleInPlatform';
+  anden: number;
+  people: number;
+}
+
+export interface PeopleInStation {
+  message: 'peopleInStation';
+  stationId: string;
+  people: number;
+}
+
 export interface PlatformOvercrowded {
   message: 'platformOvercrowded';
   platform: string;
@@ -94,6 +106,8 @@ export type SimulationMessage =
   | MoveTrain
   | PeopleInLinePlatforms
   | PeopleInLineStations
+  | PeopleInPlatform
+  | PeopleInStation
   | PeopleInTrains
   | PeopleInMetro
   | PeopleInSimulation

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -23,6 +23,8 @@ export class SimulationStateService {
 
   readonly platformsPeople = new Map<string, number>();
   readonly stationsPeople = new Map<string, number>();
+  readonly andenPeople = new Map<number, number>();
+  readonly stationIdPeople = new Map<string, number>();
 
   initLines(lines: string[]): void {
     for (const line of lines) {
@@ -38,6 +40,8 @@ export class SimulationStateService {
     this.trainsPeople = 0;
     for (const key of this.platformsPeople.keys()) this.platformsPeople.set(key, 0);
     for (const key of this.stationsPeople.keys()) this.stationsPeople.set(key, 0);
+    this.andenPeople.clear();
+    this.stationIdPeople.clear();
     this.dirty = true;
   }
 
@@ -89,6 +93,12 @@ export class SimulationStateService {
         break;
       case 'peopleInLineStations':
         this.stationsPeople.set(msg.line.slice(1), msg.people);
+        break;
+      case 'peopleInPlatform':
+        this.andenPeople.set(msg.anden, msg.people);
+        break;
+      case 'peopleInStation':
+        this.stationIdPeople.set(msg.stationId, msg.people);
         break;
       case 'peopleInTrains':
         this.trainsPeople = msg.people;

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -81,6 +81,8 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private labelVisible: boolean[] = [];
   private stationLineMap = new Map<string, string[]>();
+  private stationPlatformIds = new Map<string, string[]>();
+  private stationNormalizedMap = new Map<string, string>();
 
   // Sparkline history
   peopleHistory: number[] = Array(40).fill(0);
@@ -106,6 +108,10 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   ngOnInit(): void {
     this.buildStationLineMap();
+    for (const s of this.metroData.stations) {
+      const normalized = s.name.normalize('NFD').replace(/\p{Mn}/gu, '');
+      this.stationNormalizedMap.set(normalized, s.name);
+    }
   }
 
   ngAfterViewInit(): void {
@@ -497,6 +503,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private buildStationLineMap(): void {
     this.stationLineMap.clear();
+    this.stationPlatformIds.clear();
     // Deduplicate by line+sentido so bidirectional lines (e.g. L5 with sentido 1 & 2)
     // appear as two entries — same as L6 which has distinct line IDs '6-1' / '6-2'.
     const seen = new Map<string, Set<string>>();
@@ -508,6 +515,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
         const lines = this.stationLineMap.get(p.name) ?? [];
         lines.push(p.line);
         this.stationLineMap.set(p.name, lines);
+        const pids = this.stationPlatformIds.get(p.name) ?? [];
+        pids.push(p.id);
+        this.stationPlatformIds.set(p.name, pids);
       }
     }
   }
@@ -964,16 +974,24 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   get stationLabelItems() {
+    // Build transit map: original-station-name → total people in station hall
+    // Station actors send "Station_NOMBRE_CODE" keys; we match by normalized denominacion.
+    const transitByName = new Map<string, number>();
+    this.state.stationIdPeople.forEach((count, stationId) => {
+      const parts = stationId.replace(/^Station_/, '').split('_');
+      const normalized = parts.slice(0, -1).join(' ');
+      const originalName = this.stationNormalizedMap.get(normalized);
+      if (originalName) transitByName.set(originalName, (transitByName.get(originalName) ?? 0) + count);
+    });
+
     return this.metroData.stations.map(s => {
-      const lines = this.stationLineMap.get(s.name) ?? [];
-      // Count occurrences per line ID to split aggregated totals across directions
-      const lineOcc = new Map<string, number>();
-      for (const l of lines) lineOcc.set(l, (lineOcc.get(l) ?? 0) + 1);
-      const platforms = lines.map(l => ({
-        line:  l,
-        total: Math.round((this.state.platformsPeople.get(l) ?? 0) / (lineOcc.get(l) ?? 1)),
+      const lines      = this.stationLineMap.get(s.name) ?? [];
+      const platformIds = this.stationPlatformIds.get(s.name) ?? [];
+      const platforms  = platformIds.map((pid, idx) => ({
+        line:  lines[idx] ?? '',
+        total: this.state.andenPeople.get(parseInt(pid, 10)) ?? 0,
       }));
-      const transit = lines.reduce((sum, l) => sum + (this.state.stationsPeople.get(l) ?? 0), 0);
+      const transit = transitByName.get(s.name) ?? 0;
       const total   = transit + platforms.reduce((sum, p) => sum + p.total, 0);
       return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms, total, transit };
     });


### PR DESCRIPTION
## Summary

- **Fix inflación ×4.33**: la fórmula de Simulator.scala dividía por `86_400_000` ms/día y luego multiplicaba por `hourMultiplier` sin normalizar. Con `sum(HourDistribution) = 104`, generaba 4.33× más personas de lo esperado. Ahora: `baseCount = dailyEntrance × hourMultiplier / 104 × TimeStepMs / 3_600_000`, lo que garantiza que la integral diaria = `dailyEntrance`.
- **Fix andenes simétricos**: el frontend dividía el total de la línea entre el nº de andenes en la estación → siempre el mismo valor por dirección. Ahora se envían conteos per-andén (`CODIGOANDEN`) y per-actor-de-estación desde el backend.
- **Gente en tránsito**: los datos de estación ya se trackeaban en el simulador pero solo llegaban como totales por línea. Ahora se envían por actor de estación y el frontend los suma correctamente por estación física (con matching de nombres sin diacríticos).

## Cambios

**Backend (`metro-sim`)**
- `Simulator.scala`: nueva fórmula de spawn; `partialPerson` separado del multiplicador de hora
- `messages/Messages.scala`: dos nuevos `UIMessage` — `PeopleInSpecificPlatform(anden, people)` y `PeopleInSpecificStation(stationId, people)`
- `Line.scala`: en cada `LineTick` reenvía conteos individuales de andén y estación a UI
- `UI.scala`: publica `peopleInPlatform:{codigoanden}` y `peopleInStation:{stationId}` al WebSocket

**Frontend (`metro`)**
- `messages.ts`: interfaces `PeopleInPlatform` y `PeopleInStation`
- `simulation-state.service.ts`: mapas `andenPeople` y `stationIdPeople`; se limpian en reset
- `train.component.ts`: `buildStationLineMap` también construye `stationPlatformIds`; `stationLabelItems` usa counts per-andén (rompe la simetría) y suma actors por estación física para tránsito

## Test plan

- [ ] Arrancar simulador y esperar 2 min simulados: verificar que en Empalme los dos andenes muestran valores distintos
- [ ] Verificar que el número total de personas en el sistema es razonable (no 80 personas por andén a los 2 min)
- [ ] Verificar que el panel de estación muestra TRANSIT con personas en tránsito (entre entrada y andén)
- [ ] Verificar que el reset limpia los nuevos conteos correctamente