### PR TITLE
feat: station transit, platform destinations, train click, perf

### DIFF
--- a/metro-sim/src/main/scala/Line.scala
+++ b/metro-sim/src/main/scala/Line.scala
@@ -20,34 +20,22 @@ object Line {
       Behaviors.receiveMessage {
 
         case LineTick =>
-          val platformPeople = platforms.values.sum
-          val stationPeople = stations.values.sum
-          ui ! PeopleInLinePlatforms(lineId, platformPeople)
-          ui ! PeopleInLineStations(lineId, stationPeople)
-          platforms.foreach { case (platformId, count) =>
-            platformId.split("_").last.toIntOption.foreach { anden =>
-              ui ! PeopleInSpecificPlatform(anden, count)
-            }
-          }
-          stations.foreach { case (stationId, count) =>
-            ui ! PeopleInSpecificStation(stationId, count)
-          }
+          ui ! PeopleInLinePlatforms(lineId, platforms.values.sum)
+          ui ! PeopleInLineStations(lineId, stations.values.sum)
           Behaviors.same
 
         case PeopleInPlatform(platformId, people) =>
-          if (people > 0) {
-            scribe.debug(s"There are $people people in platform $platformId")
-            if (people > 100) ui ! PlatformOvercrowded(platformId, people)
-          }
+          if (people > 100) ui ! PlatformOvercrowded(platformId, people)
           platforms(platformId) = people
+          platformId.split("_").last.toIntOption.foreach { anden =>
+            ui ! PeopleInSpecificPlatform(anden, people)
+          }
           Behaviors.same
 
         case PeopleInStation(stationId, people) =>
-          if (people > 0) {
-            scribe.debug(s"There are $people people in station $stationId")
-            if (people > 1000) ui ! StationOvercrowded(stationId, people)
-          }
+          if (people > 1000) ui ! StationOvercrowded(stationId, people)
           stations(stationId) = people
+          ui ! PeopleInSpecificStation(stationId, people)
           Behaviors.same
       }
     }

--- a/metro-sim/src/main/scala/Platform.scala
+++ b/metro-sim/src/main/scala/Platform.scala
@@ -21,7 +21,7 @@ object Platform {
         scribe.debug(s"Setting platform $name to empty mode. Next: ${next.path.name}")
         Behaviors.setup { context =>
           Behaviors.withTimers { timers =>
-            timers.startTimerWithFixedDelay("stats-tick", PlatformStatsTick, 3.seconds, 1.second)
+            timers.startTimerWithFixedDelay("stats-tick", PlatformStatsTick, 3.seconds, 3.seconds)
             val people: scala.collection.mutable.Map[String, (ActorRef[PersonMessage], Boolean)] =
               scala.collection.mutable.Map.empty
             empty(context.self, line, name, next, people)

--- a/metro-sim/src/main/scala/Station.scala
+++ b/metro-sim/src/main/scala/Station.scala
@@ -13,7 +13,7 @@ object Station {
   def apply(line: ActorRef[LineMessage], name: String): Behavior[StationMessage] =
     Behaviors.setup { context =>
       Behaviors.withTimers { timers =>
-        timers.startTimerWithFixedDelay("stats-tick", StationStatsTick, 3.seconds, 1.second)
+        timers.startTimerWithFixedDelay("stats-tick", StationStatsTick, 3.seconds, 3.seconds)
 
         val people: scala.collection.mutable.Map[String, ActorRef[PersonMessage]] =
           scala.collection.mutable.Map.empty

--- a/metro-sim/src/main/scala/Train.scala
+++ b/metro-sim/src/main/scala/Train.scala
@@ -24,6 +24,10 @@ object Train {
     Behaviors.setup { context =>
       val rng = new Random
 
+      val pathByName: Map[String, Path] = allPaths.map { pp =>
+        Metro.platformName(pp.features.denominacion, pp.features.codigoanden) -> pp
+      }.toMap
+
       def travelMsForPath(p: Option[Path]): Long = p match {
         case Some(pp) if pp.features.velocidadtramoanterior > 0 && pp.features.longitudtramoanterior > 0 =>
           (pp.features.longitudtramoanterior / pp.features.velocidadtramoanterior * 3600).toLong
@@ -49,8 +53,7 @@ object Train {
         val selfRef   = context.self
 
         def findPlatformPath(p: ActorRef[PlatformMessage]): Option[Path] =
-          allPaths.find(pp =>
-            Metro.platformName(pp.features.denominacion, pp.features.codigoanden) == p.path.name)
+          pathByName.get(p.path.name)
 
         Behaviors.receiveMessage {
 

--- a/metro/src/app/services/metro-data.service.ts
+++ b/metro/src/app/services/metro-data.service.ts
@@ -3,16 +3,30 @@ import { Injectable } from '@angular/core';
 import { Madrid } from '../madrid';
 import { Station } from '../station';
 import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../constants';
+import rawPaths from '../../assets/tramos.json';
 
 @Injectable({ providedIn: 'root' })
 export class MetroDataService {
 
   readonly stations: Station[];
   readonly paths: Station[];
+  readonly lineDestinations: Map<string, string>;
 
   constructor() {
     const madrid = new Madrid(CANVAS_WIDTH, CANVAS_HEIGHT);
     this.stations = madrid.stations;
     this.paths = madrid.paths;
+
+    // Build map: "line/sentido" → terminal station name (highest NUMEROORDEN)
+    const maxOrder = new Map<string, { order: number; name: string }>();
+    for (const f of rawPaths.features) {
+      const p = f.properties;
+      const key = `${p.NUMEROLINEAUSUARIO}/${p.SENTIDO}`;
+      const order = p.NUMEROORDEN ?? 0;
+      const cur = maxOrder.get(key);
+      if (!cur || order > cur.order) maxOrder.set(key, { order, name: p.DENOMINACION });
+    }
+    this.lineDestinations = new Map();
+    maxOrder.forEach((v, k) => this.lineDestinations.set(k, v.name));
   }
 }

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -675,10 +675,18 @@
 /* ── Per-platform row ────────────────────────────────────── */
 .stn-platform {
   display: grid;
-  grid-template-columns: 18px 1fr;
+  grid-template-columns: 18px 1fr auto;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   height: 14px;
+}
+.stn-direction {
+  font-size: 8px;
+  color: var(--t-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  letter-spacing: 0.02em;
 }
 .line-chip {
   width: 16px; height: 12px;
@@ -723,3 +731,56 @@
 .stn-label-wrap.is-selected .stn-name             { color: var(--amber); -webkit-text-stroke-color: rgba(20,15,5,0.92); }
 .stn-label-wrap.is-selected .stn-tick             { background: var(--amber); box-shadow: 0 0 6px var(--amber); }
 .stn-label-wrap.is-selected .stn-panel::before    { background: var(--amber); opacity: 1; box-shadow: 0 0 6px var(--amber); }
+
+/* ── Train occupancy tooltip ────────────────────────────────── */
+.train-tooltip {
+  position: absolute;
+  transform: translate(-50%, -140%);
+  pointer-events: none;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  filter: drop-shadow(0 2px 8px rgba(0,0,0,0.6));
+}
+.train-tooltip-line {
+  font-family: var(--sans, system-ui);
+  font-size: 8px;
+  font-weight: 700;
+  width: 16px; height: 12px;
+  line-height: 12px;
+  text-align: center;
+  border-radius: 1px;
+  color: #fff;
+}
+.train-tooltip-body {
+  background: var(--bg-2);
+  border: 1px solid var(--line-2);
+  border-radius: 3px;
+  padding: 4px 6px;
+  display: flex;
+  align-items: baseline;
+  gap: 2px;
+  min-width: 70px;
+  flex-direction: column;
+}
+.train-tooltip-pax  { font-size: 13px; font-weight: 700; color: var(--t-1); font-variant-numeric: tabular-nums; }
+.train-tooltip-sep  { font-size: 10px; color: var(--t-3); }
+.train-tooltip-cap  { font-size: 10px; color: var(--t-2); font-variant-numeric: tabular-nums; }
+.train-tooltip-unit { font-size: 8px; color: var(--t-3); letter-spacing: 0.08em; margin-left: 2px; }
+.train-tooltip-bar {
+  width: 100%; height: 3px;
+  background: var(--bg-3);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 2px;
+}
+.train-tooltip-fill {
+  height: 100%;
+  background: #4ade80;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+}
+.train-tooltip-fill.warn { background: #fbbf24; }
+.train-tooltip-fill.over { background: #f87171; }

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -23,19 +23,18 @@
                 <span class="k">TOTAL</span>
                 <span class="v">{{ fmtCount(item.total) }}</span>
               </div>
-              @if (item.transit > 0) {
-                <div class="stn-panel-row stn-transit">
-                  <span class="k">↳ TRANSIT</span>
-                  <span class="v">{{ fmtCount(item.transit) }}</span>
-                </div>
-              }
+              <div class="stn-panel-row stn-transit">
+                <span class="k">↳ TRANSIT</span>
+                <span class="v">{{ fmtCount(item.transit) }}</span>
+              </div>
               <div class="stn-panel-sep">
                 <span>{{ item.lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item.lines.length }}</span>
               </div>
-              @for (p of item.platforms; track p.line) {
+              @for (p of item.platforms; track p.line + p.destination) {
                 <div class="stn-platform">
                   <span class="line-chip" [style.background]="lineColors(p.line)"
                         [style.color]="p.line === 'R' ? '#000' : '#fff'">{{ p.line }}</span>
+                  <span class="stn-direction">→ {{ p.destination }}</span>
                   <span class="stn-platform-count">{{ fmtCount(p.total) }}</span>
                 </div>
               }
@@ -45,6 +44,28 @@
       }
     </div>
   </div>
+
+  <!-- Train occupancy tooltip -->
+  @if (selectedTrain) {
+    <div class="train-tooltip"
+         [style.left.px]="trainTooltipX"
+         [style.top.px]="trainTooltipY">
+      <div class="train-tooltip-line" [style.background]="lineColors(selectedTrain.line)">{{ selectedTrain.line }}</div>
+      <div class="train-tooltip-body">
+        <span class="train-tooltip-pax">{{ selectedTrain.people }}</span>
+        <span class="train-tooltip-sep">/</span>
+        <span class="train-tooltip-cap">{{ selectedTrain.capacity }}</span>
+        <span class="train-tooltip-unit">PAX</span>
+        <div class="train-tooltip-bar">
+          <div class="train-tooltip-fill"
+               [style.width.%]="selectedTrain.capacity > 0 ? (selectedTrain.people / selectedTrain.capacity * 100) : 0"
+               [class.warn]="selectedTrain.people / selectedTrain.capacity > 0.5"
+               [class.over]="selectedTrain.people / selectedTrain.capacity > 0.8">
+          </div>
+        </div>
+      </div>
+    </div>
+  }
 
   <!-- Corner brackets -->
   <div class="corners" aria-hidden="true">

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -30,7 +30,7 @@
               <div class="stn-panel-sep">
                 <span>{{ item.lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item.lines.length }}</span>
               </div>
-              @for (p of item.platforms; track p.line + p.destination) {
+              @for (p of item.platforms; track p.id) {
                 <div class="stn-platform">
                   <span class="line-chip" [style.background]="lineColors(p.line)"
                         [style.color]="p.line === 'R' ? '#000' : '#fff'">{{ p.line }}</span>

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1032,6 +1032,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
         const line = lines[idx] ?? '';
         const destination = this.metroData.lineDestinations.get(`${line}/${pe.sentido}`) ?? '';
         return {
+          id: pe.id,
           line,
           destination,
           total: this.state.andenPeople.get(parseInt(pe.id, 10)) ?? 0,

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -81,8 +81,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private labelVisible: boolean[] = [];
   private stationLineMap = new Map<string, string[]>();
-  private stationPlatformIds = new Map<string, string[]>();
+  private stationPlatformIds = new Map<string, { id: string; sentido: string }[]>();
   private stationNormalizedMap = new Map<string, string>();
+
+  selectedTrainId: string | null = null;
+  trainTooltipX = 0;
+  trainTooltipY = 0;
 
   // Sparkline history
   peopleHistory: number[] = Array(40).fill(0);
@@ -355,6 +359,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
       this.drawTrains(timestamp);
       this.updateStationsOverlay();
+      this.updateTrainTooltip();
       this.state.dirty      = false;
       this.needsTrainRedraw = false;
 
@@ -453,14 +458,42 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     return bestIdx;
   }
 
+  private findNearestTrain(cx: number, cy: number, hitPx = 24): string | null {
+    const hitCanvas = hitPx / this.currentScale;
+    let best: string | null = null;
+    let bestDist = hitCanvas * hitCanvas;
+    for (const t of this.state.trains) {
+      const tx = t.x * this.currentScale + this.panX;
+      const ty = t.y * this.currentScale + this.panY;
+      const d2 = (cx - tx) ** 2 + (cy - ty) ** 2;
+      if (d2 < bestDist) { bestDist = d2; best = t.id; }
+    }
+    return best;
+  }
+
+  get selectedTrain() {
+    return this.selectedTrainId ? this.state.getTrain(this.selectedTrainId) : undefined;
+  }
+
   onStationLabelClick(idx: number): void {
     this.selectedStationIdx = idx === this.selectedStationIdx ? -1 : idx;
   }
 
   private handleMapClick(clientX: number, clientY: number): void {
     const rect = (this.canvasContainer.nativeElement as HTMLElement).getBoundingClientRect();
-    const bestIdx = this.findNearestStation(clientX - rect.left, clientY - rect.top);
+    const mx = clientX - rect.left;
+    const my = clientY - rect.top;
+
+    const nearTrain = this.findNearestTrain(mx, my);
+    if (nearTrain) {
+      this.selectedTrainId = nearTrain === this.selectedTrainId ? null : nearTrain;
+      this.selectedStationIdx = -1;
+      return;
+    }
+
+    const bestIdx = this.findNearestStation(mx, my);
     this.selectedStationIdx = bestIdx === this.selectedStationIdx ? -1 : bestIdx;
+    this.selectedTrainId = null;
   }
 
   private updateStationsOverlay(): void {
@@ -501,6 +534,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     }
   }
 
+  private updateTrainTooltip(): void {
+    if (!this.selectedTrainId) return;
+    const t = this.state.getTrain(this.selectedTrainId);
+    if (!t) { this.selectedTrainId = null; return; }
+    this.trainTooltipX = t.x * this.currentScale + this.panX;
+    this.trainTooltipY = t.y * this.currentScale + this.panY;
+  }
+
   private buildStationLineMap(): void {
     this.stationLineMap.clear();
     this.stationPlatformIds.clear();
@@ -516,7 +557,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
         lines.push(p.line);
         this.stationLineMap.set(p.name, lines);
         const pids = this.stationPlatformIds.get(p.name) ?? [];
-        pids.push(p.id);
+        pids.push({ id: p.id, sentido: p.sentido ?? '' });
         this.stationPlatformIds.set(p.name, pids);
       }
     }
@@ -985,12 +1026,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     });
 
     return this.metroData.stations.map(s => {
-      const lines      = this.stationLineMap.get(s.name) ?? [];
-      const platformIds = this.stationPlatformIds.get(s.name) ?? [];
-      const platforms  = platformIds.map((pid, idx) => ({
-        line:  lines[idx] ?? '',
-        total: this.state.andenPeople.get(parseInt(pid, 10)) ?? 0,
-      }));
+      const lines       = this.stationLineMap.get(s.name) ?? [];
+      const platformEntries = this.stationPlatformIds.get(s.name) ?? [];
+      const platforms   = platformEntries.map((pe, idx) => {
+        const line = lines[idx] ?? '';
+        const destination = this.metroData.lineDestinations.get(`${line}/${pe.sentido}`) ?? '';
+        return {
+          line,
+          destination,
+          total: this.state.andenPeople.get(parseInt(pe.id, 10)) ?? 0,
+        };
+      });
       const transit = transitByName.get(s.name) ?? 0;
       const total   = transit + platforms.reduce((sum, p) => sum + p.total, 0);
       return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms, total, transit };


### PR DESCRIPTION
## Summary

- TRANSIT siempre visible en panel de estación (antes se ocultaba con `@if transit > 0`)
- Cada andén muestra la estación terminal (`→ CASA DE CAMPO / → ALAMEDA DE OSUNA`)
- Click en un tren muestra tooltip de ocupación (personas / capacidad + barra de color)
- Reducción de mensajes de actor internos ~3×

## Cambios

**Panel de estación**
- `train.component.html`: eliminado `@if (item.transit > 0)` — TRANSIT siempre visible
- `metro-data.service.ts`: nuevo `lineDestinations: Map<string, string>` — clave `line/sentido` → última estación por `NUMEROORDEN`
- `train.component.ts`: `stationPlatformIds` ahora guarda `{id, sentido}`; `stationLabelItems` añade `destination` a cada plataforma
- `train.component.html + css`: nueva columna `→ DESTINO` en cada fila de andén

**Click en tren**
- `train.component.ts`: `findNearestTrain()`, `handleMapClick` comprueba trenes antes que estaciones, `updateTrainTooltip()` en RAF
- `train.component.html`: overlay `<div class="train-tooltip">` con chip de línea, PAX/CAP y barra de color (verde/amarillo/rojo)
- `train.component.css`: estilos del tooltip

**Performance (backend)**
- `Station.scala` + `Platform.scala`: `StatsTick` de 1 s → 3 s (−67% mensajes internos de stats)
- `Line.scala`: reenvío por-andén/estación inmediato al recibir el dato, no batched en `LineTick`
- `Train.scala`: `allPaths.find(...)` O(n) → `Map[String, Path]` precomputado O(1)

## Test plan

- [ ] Abrir panel de estación: TRANSIT siempre visible (aunque sea 0)
- [ ] Cada andén muestra flecha con estación terminal diferente por sentido
- [ ] Click en un tren: aparece tooltip con chip de línea, X/Y PAX y barra
- [ ] Click otra vez en el mismo tren: se cierra
- [ ] Verificar que el simulador sigue mostrando datos de ocupación correctos tras el cambio de tick