### PR TITLE
perf: Wave 2 — lookups O(1) y caché Dijkstra en simulador

### DIFF
--- a/metro-sim/src/main/scala/Main.scala
+++ b/metro-sim/src/main/scala/Main.scala
@@ -276,11 +276,11 @@ object Guardian {
       scheduleHourlyAdjustments()
 
       // Simulator
-      val allStationAndPlatformActors: List[ActorRef[_]] =
-        stationActors.values.toList ++ allPlatformActors.values.toList
+      val actorsByName: Map[String, ActorRef[_]] =
+        stationActors ++ allPlatformActors
 
       val simulatorRef = context.spawn(
-        Simulator(ui, allStationAndPlatformActors, metroGraph, stationIdsEntrance, odMatrix, districtData),
+        Simulator(ui, actorsByName, metroGraph, stationIdsEntrance, odMatrix, districtData),
         "simulator"
       )
 

--- a/metro-sim/src/main/scala/Metro.scala
+++ b/metro-sim/src/main/scala/Metro.scala
@@ -35,30 +35,32 @@ class Metro(sortedLinePaths: Map[String, Seq[Path]], weightStationStation: Doubl
       .flatMap { case (line: String, paths: Seq[Path]) => paths.map { x =>
         new PlatformNode(Metro.platformName(x.features.denominacion, x.features.codigoanden), Seq("L" + line))
       } }
+    val stationsByName: Map[String, MetroNode] = stations.map(s => s.name -> s).toMap
+    val platformsByName: Map[String, MetroNode] = platforms.map(p => p.name -> p).toMap
     val nodes: Iterable[MetroNode] = stations ++ platforms
     val lineEdges: Iterable[WDiEdge[MetroNode]] = sortedLinePaths
       .values
-      .flatMap(x => buildLineEdges(x, stations, platforms))
-    val interLineEdges: Iterable[WDiEdge[MetroNode]] = buildInterLineEdges(sortedLinePaths, stations, platforms)
+      .flatMap(x => buildLineEdges(x, stationsByName, platformsByName))
+    val interLineEdges: Iterable[WDiEdge[MetroNode]] = buildInterLineEdges(sortedLinePaths, stationsByName, platformsByName)
     Graph.from(nodes, lineEdges ++ interLineEdges)
   }
 
-  def buildLineEdges(linePaths: Seq[Path], stations: Iterable[MetroNode], platforms: Iterable[MetroNode])
+  def buildLineEdges(linePaths: Seq[Path], stationsByName: Map[String, MetroNode], platformsByName: Map[String, MetroNode])
   : Seq[WDiEdge[MetroNode]] = {
     (for {
       i <- linePaths.indices
       currentStationName: String = Metro.stationName(
         linePaths(i).features.denominacion, linePaths(i).features.codigoestacion)
-      currentStation: MetroNode = stations.filter(x => x.name == currentStationName).head
+      currentStation: MetroNode = stationsByName(currentStationName)
       weight: Double = linePaths(i).features.longitudtramoanterior
       currentPlatformName: String = Metro.platformName(
         linePaths(i).features.denominacion, linePaths(i).features.codigoanden)
-      currentPlatform: MetroNode = platforms.filter(x => x.name == currentPlatformName).head
+      currentPlatform: MetroNode = platformsByName(currentPlatformName)
       nextPath: Path = if (i + 1 < linePaths.length) linePaths(i + 1) else linePaths.head
       nextStationName: String = Metro.stationName(nextPath.features.denominacion, nextPath.features.codigoestacion)
-      nextStation: MetroNode = stations.filter(x => x.name == nextStationName).head
+      nextStation: MetroNode = stationsByName(nextStationName)
       nextPlatformName: String = Metro.platformName(nextPath.features.denominacion, nextPath.features.codigoanden)
-      nextPlatform: MetroNode = platforms.filter(x => x.name == nextPlatformName).head
+      nextPlatform: MetroNode = platformsByName(nextPlatformName)
       s1: WDiEdge[MetroNode] = WDiEdge(currentStation, currentPlatform)(weightStationPlatform)
       s1bis: WDiEdge[MetroNode] = WDiEdge(currentPlatform, currentStation)(weightStationPlatform)
       p: WDiEdge[MetroNode] = WDiEdge(currentPlatform, nextPlatform)(weight)
@@ -67,7 +69,7 @@ class Metro(sortedLinePaths: Map[String, Seq[Path]], weightStationStation: Doubl
     } yield List(s1, s1bis, p, s2, s2bis)).flatten
   }
 
-  def buildInterLineEdges(lines: Map[String, Seq[Path]], stations: Iterable[MetroNode], platforms: Iterable[MetroNode])
+  def buildInterLineEdges(lines: Map[String, Seq[Path]], stationsByName: Map[String, MetroNode], platformsByName: Map[String, MetroNode])
   : Iterable[WDiEdge[MetroNode]] = {
     val stationWithTransfers: Iterable[Iterable[Path]] = lines
       .values
@@ -80,7 +82,7 @@ class Metro(sortedLinePaths: Map[String, Seq[Path]], weightStationStation: Doubl
       .map { case (x: Iterable[Path]) =>
         x.map { case (y: Path) =>
           val stationWithTransferName: String = Metro.stationName(y.features.denominacion, y.features.codigoestacion)
-          stations.filter { case (z: StationNode) => z.name == stationWithTransferName }.head
+          stationsByName(stationWithTransferName)
         } }
       .map { case (x: Iterable[MetroNode]) => computePairs(x.toList) }
     transferPairs

--- a/metro-sim/src/main/scala/Person.scala
+++ b/metro-sim/src/main/scala/Person.scala
@@ -20,6 +20,7 @@ object Person {
       val selfRef    = context.self
 
       var trackingUi: Option[ActorRef[UIMessage]] = None
+      val pathIndexMap: Map[String, Int] = path.zipWithIndex.map { case (ref, idx) => ref.path.name -> idx }.toMap
 
       val destination: String = path.last.path.name
         .stripPrefix(Metro.StationPrefix)
@@ -40,7 +41,7 @@ object Person {
         ref.asInstanceOf[ActorRef[PlatformMessage]]
 
       def nextNodeIndex(currentRef: ActorRef[_]): Int =
-        path.indexWhere(_.path.name == currentRef.path.name) + 1
+        pathIndexMap.getOrElse(currentRef.path.name, -2) + 1
 
       // Start: request entry into first node (always a station)
       scribe.debug(s"Person $personName to ${path.last.path.name} wants to enter ${path.head.path.name}")
@@ -173,7 +174,7 @@ object Person {
         Behaviors.receiveMessage {
 
           case ArrivedAtPlatformToPeople(platform) =>
-            val platformIdx = path.indexWhere(_.path.name == platform.path.name)
+            val platformIdx = pathIndexMap.getOrElse(platform.path.name, -1)
             if (platformIdx < 0) {
               Behaviors.same  // not our stop
             } else {

--- a/metro-sim/src/main/scala/Simulator.scala
+++ b/metro-sim/src/main/scala/Simulator.scala
@@ -26,7 +26,7 @@ object Simulator {
 
   def apply(
     ui: ActorRef[UIMessage],
-    stationActors: List[ActorRef[_]],
+    actorsByName: Map[String, ActorRef[_]],
     metroGraph: Graph[MetroNode, WDiEdge],
     stationIdsEntrance: Map[StationIds, Option[Entrance]],
     odMatrix: ODMatrix,
@@ -37,6 +37,8 @@ object Simulator {
         timers.startTimerWithFixedDelay("stats-tick", SimulatorStatsTick, 3.seconds, 1.second)
 
         val people: scala.collection.mutable.Map[String, ActorRef[PersonMessage]] =
+          scala.collection.mutable.Map.empty
+        val pathCache: scala.collection.mutable.Map[(String, String), Seq[ActorRef[_]]] =
           scala.collection.mutable.Map.empty
         var simulationPeople: Int = 0
         var trackedPerson: Option[ActorRef[PersonMessage]] = None
@@ -118,10 +120,11 @@ object Simulator {
               _ = startNode.setPartialPerson(floatPart)
               _ <- 1 to integerPart
               destinationNode = pickDestination(startNode, hourKey)
-              journey: Option[metroGraph.Path] = startNode.shortestPathTo(destinationNode, (e: metroGraph.EdgeT) => e.weight)
-              path = journey.get.nodes
-                .map(x => stationActors.filter(y => y.path.name == x.name).head)
-                .toSeq
+              cacheKey = (startNode.value.name, destinationNode.value.name)
+              path = pathCache.getOrElseUpdate(cacheKey, {
+                val journey = startNode.shortestPathTo(destinationNode, (e: metroGraph.EdgeT) => e.weight)
+                journey.get.nodes.map(x => actorsByName(x.name)).toSeq
+              })
               uuid   = java.util.UUID.randomUUID.toString
               person = context.spawn(Person(selfRef, path), uuid)
               _ = people(person.path.name) = person


### PR DESCRIPTION
## Summary

- **C1** (`Main.scala` + `Simulator.scala`): cambiado `List[ActorRef[_]]` → `Map[String, ActorRef[_]]`. Lookup de actor por nombre de O(N) a O(1); elimina ~500K escaneos lineales por tick con 100 personas.
- **C2** (`Metro.scala`): preconstruidos `stationsByName`/`platformsByName` en `buildMetroGraph()`; los `.filter(...).head` en `buildLineEdges` y `buildInterLineEdges` son ahora lookups directos de mapa.
- **C3** (`Simulator.scala`): `pathCache: mutable.Map[(String, String), Seq[ActorRef[_]]]` memoiza `shortestPathTo` por par (origen, destino). Dijkstra O((V+E)logV) solo se ejecuta la primera vez; ~99% de hits esperados.
- **C4** (`Person.scala`): `pathIndexMap: Map[String, Int]` precalculado al crear el actor. `nextNodeIndex` y el check de desembarco en `inTrain` usan O(1) en lugar de `indexWhere` O(path_len).

## Test plan

- [ ] `sbt compile` sin warnings nuevos ✓ (verificado antes del PR)
- [ ] Ejecutar simulación y comprobar que los trenes y personas se mueven correctamente
- [ ] Path debug `/debug` Empalme→Batán devuelve 9 nodos vía Platform_420
- [ ] El pasajero rastreado no pasa por Colonia Jardín