### PR TITLE
fix: botón estaciones a cualquier zoom + cobertura en CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,29 @@ jobs:
           name: coverage-report
           path: metro/coverage/metro/
           retention-days: 30
+
+  simulator:
+    name: Scala Simulator
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: metro-sim
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: sbt
+
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Compile
+        run: sbt compile
+
+      - name: Test
+        run: sbt test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,5 +30,13 @@ jobs:
       - name: Build
         run: npm run build -- --configuration=development
 
-      - name: Test
-        run: npm test -- --watch=false --browsers=ChromeHeadless
+      - name: Test with coverage
+        run: npm test -- --watch=false --browsers=ChromeHeadless --code-coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: metro/coverage/metro/
+          retention-days: 30

--- a/metro-sim/build.sbt
+++ b/metro-sim/build.sbt
@@ -15,6 +15,7 @@ lazy val root = (project in file(".")).
        "org.apache.pekko" %% "pekko-slf4j" % "1.1.3",
        "com.typesafe.play" %% "play-json" % "2.9.2",
        "org.geolatte" % "geolatte-geom" % "1.8.2",
-       "org.geolatte" %% "geolatte-geom-scala" % "1.7.0"
+       "org.geolatte" %% "geolatte-geom-scala" % "1.7.0",
+       "org.scalatest" %% "scalatest" % "3.2.17" % Test
      )
    )

--- a/metro-sim/project/plugins.sbt
+++ b/metro-sim/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.3")

--- a/metro-sim/src/test/scala/MetroSpec.scala
+++ b/metro-sim/src/test/scala/MetroSpec.scala
@@ -1,0 +1,198 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scala.collection.immutable.SortedMap
+
+import parser.{EntranceParser, MetroParser, Path, StationParser}
+import utils.{Distribution, Position}
+
+
+class MetroSpec extends AnyFlatSpec with Matchers {
+
+  // ── Metro.stationName ────────────────────────────────────────────────────
+
+  "Metro.stationName" should "add Station_ prefix" in {
+    Metro.stationName("Sol", "1") should startWith(Metro.StationPrefix)
+  }
+
+  it should "replace spaces with underscores" in {
+    Metro.stationName("Casa de Campo", "42") should include("Casa_de_Campo")
+  }
+
+  it should "strip diacritics" in {
+    val name = Metro.stationName("Príncipe Pío", "99")
+    name should not include "í"
+    name should include("Principe_Pio")
+  }
+
+  // ── Metro.platformName ───────────────────────────────────────────────────
+
+  "Metro.platformName" should "add Platform_ prefix" in {
+    Metro.platformName("Sol", 1) should startWith(Metro.PlatformPrefix)
+  }
+
+  it should "include the platform code" in {
+    Metro.platformName("Sol", 420) should endWith("420")
+  }
+
+  it should "strip diacritics" in {
+    val name = Metro.platformName("Príncipe Pío", 7)
+    name should not include "í"
+  }
+
+  // ── Position ──────────────────────────────────────────────────────────────
+
+  "Position" should "place Madrid center at roughly canvas center" in {
+    val p = new Position(40.4202961, -3.718762)
+    p.x shouldBe (1700.0 +- 1.0)
+    p.y shouldBe (1000.0 +- 1.0)
+  }
+
+  it should "place a point north of center higher on canvas (smaller y)" in {
+    val center = new Position(40.4202961, -3.718762)
+    val north  = new Position(40.5, -3.718762)
+    north.y should be < center.y
+  }
+
+  it should "place a point east of center further right (larger x)" in {
+    val center = new Position(40.4202961, -3.718762)
+    val east   = new Position(40.4202961, -3.6)
+    east.x should be > center.x
+  }
+
+  // ── Distribution ─────────────────────────────────────────────────────────
+
+  "Distribution" should "return 0 when probability is at or below the lowest key" in {
+    val d = new Distribution(SortedMap(0.0 -> 1, 0.5 -> 2, 0.9 -> 3))
+    d.value(0.0) shouldBe 0
+  }
+
+  it should "return the correct bucket for a mid probability" in {
+    val d = new Distribution(SortedMap(0.0 -> 1, 0.5 -> 2, 0.9 -> 3))
+    d.value(0.3) shouldBe 1
+    d.value(0.7) shouldBe 2
+  }
+
+  it should "return the highest bucket for high probability" in {
+    val d = new Distribution(SortedMap(0.0 -> 1, 0.5 -> 2, 0.9 -> 3))
+    d.value(0.95) shouldBe 3
+  }
+
+  // ── EntranceParser ────────────────────────────────────────────────────────
+
+  "EntranceParser" should "parse a valid entrance JSON" in {
+    val json =
+      """|{
+         |  "entrances": [
+         |    { "entrance": { "CODIGOEMPRESA": "101", "ENTRANCE": 948967.0 } },
+         |    { "entrance": { "CODIGOEMPRESA": "102", "ENTRANCE": 193500.0 } }
+         |  ]
+         |}""".stripMargin
+    val result = new EntranceParser().parseEntrances(json)
+    result should have size 2
+    result.map(_.id) should contain ("101")
+    result.find(_.id == "101").map(_.entrance) shouldBe Some(948967.0)
+  }
+
+  it should "return empty seq for empty entrances array" in {
+    val json = """{ "entrances": [] }"""
+    new EntranceParser().parseEntrances(json) shouldBe empty
+  }
+
+  it should "skip malformed entries" in {
+    val json =
+      """|{
+         |  "entrances": [
+         |    { "entrance": { "CODIGOEMPRESA": "101", "ENTRANCE": 100.0 } },
+         |    { "entrance": { "MISSING_FIELD": true } }
+         |  ]
+         |}""".stripMargin
+    val result = new EntranceParser().parseEntrances(json)
+    result should have size 1
+  }
+
+  // ── StationParser ─────────────────────────────────────────────────────────
+
+  "StationParser" should "parse valid station features JSON" in {
+    val json =
+      """|{
+         |  "type": "FeatureCollection",
+         |  "features": [
+         |    { "properties": {
+         |        "DENOMINACION": "SOL",
+         |        "CODIGOESTACION": "1",
+         |        "CODIGOEMPRESA": "101"
+         |    }},
+         |    { "properties": {
+         |        "DENOMINACION": "GRAN VIA",
+         |        "CODIGOESTACION": "2",
+         |        "CODIGOEMPRESA": "102"
+         |    }}
+         |  ]
+         |}""".stripMargin
+    val result = new StationParser().parseStations(json)
+    result should have size 2
+    result.map(_.name) should contain ("SOL")
+    result.find(_.name == "SOL").map(_.id) shouldBe Some("1")
+  }
+
+  it should "return empty seq for no features" in {
+    val json = """{ "type": "FeatureCollection", "features": [] }"""
+    new StationParser().parseStations(json) shouldBe empty
+  }
+
+  it should "skip entries with missing required fields" in {
+    val json =
+      """|{
+         |  "type": "FeatureCollection",
+         |  "features": [
+         |    { "properties": { "DENOMINACION": "SOL", "CODIGOESTACION": "1", "CODIGOEMPRESA": "101" } },
+         |    { "properties": { "DENOMINACION": "INCOMPLETE" } }
+         |  ]
+         |}""".stripMargin
+    val result = new StationParser().parseStations(json)
+    result should have size 1
+    result.head.name shouldBe "SOL"
+  }
+
+  // ── Metro.buildMetroGraph (integration) ───────────────────────────────────
+
+  "Metro.buildMetroGraph" should "build a graph with stations and platforms" in {
+    val metro  = scala.io.Source.fromFile("data/tramos.json").mkString
+    val paths  = new MetroParser(metro).parseMetro(metro)
+    val sorted = paths
+      .groupBy(_.features.numerolineausuario)
+      .map { case (line, ps) => line -> Path.sortLinePaths(ps) }
+    val graph = new Metro(sorted, 2000, 10).buildMetroGraph()
+
+    graph.nodes.size should be > 100
+    graph.edges.size should be > 100
+    graph.nodes.exists(_.value.name.startsWith(Metro.StationPrefix))   shouldBe true
+    graph.nodes.exists(_.value.name.startsWith(Metro.PlatformPrefix))  shouldBe true
+  }
+
+  it should "contain at least one interchange (multi-line) station" in {
+    val metro  = scala.io.Source.fromFile("data/tramos.json").mkString
+    val paths  = new MetroParser(metro).parseMetro(metro)
+    val sorted = paths
+      .groupBy(_.features.numerolineausuario)
+      .map { case (line, ps) => line -> Path.sortLinePaths(ps) }
+    val graph = new Metro(sorted, 2000, 10).buildMetroGraph()
+
+    val multiLine = graph.nodes.filter { n =>
+      n.value.name.startsWith(Metro.StationPrefix) && n.value.lines.size >= 2
+    }
+    multiLine.nonEmpty shouldBe true
+  }
+
+  it should "produce station nodes with at least one line" in {
+    val metro  = scala.io.Source.fromFile("data/tramos.json").mkString
+    val paths  = new MetroParser(metro).parseMetro(metro)
+    val sorted = paths
+      .groupBy(_.features.numerolineausuario)
+      .map { case (line, ps) => line -> Path.sortLinePaths(ps) }
+    val graph = new Metro(sorted, 2000, 10).buildMetroGraph()
+
+    val stations = graph.nodes.filter(_.value.name.startsWith(Metro.StationPrefix))
+    stations.forall(_.value.lines.nonEmpty) shouldBe true
+  }
+}

--- a/metro-sim/src/test/scala/SimClockSpec.scala
+++ b/metro-sim/src/test/scala/SimClockSpec.scala
@@ -1,0 +1,98 @@
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import parser.{MetroParser, Path}
+
+
+class SimClockSpec extends AnyFlatSpec with Matchers {
+
+  // ── SimClock pure API ─────────────────────────────────────────────────────
+
+  "SimClock" should "start paused" in {
+    SimClock.reset()
+    SimClock.isPaused shouldBe true
+  }
+
+  it should "resume and pause correctly" in {
+    SimClock.reset()
+    SimClock.resume()
+    SimClock.isPaused shouldBe false
+    SimClock.pause()
+    SimClock.isPaused shouldBe true
+  }
+
+  it should "clamp speed factor to valid range" in {
+    SimClock.setSpeed(0.0)
+    SimClock.speedFactor shouldBe 0.1 +- 0.001
+
+    SimClock.setSpeed(1_000_000.0)
+    SimClock.speedFactor shouldBe 10_000.0 +- 0.001
+
+    SimClock.setSpeed(10.0)
+    SimClock.speedFactor shouldBe 10.0 +- 0.001
+  }
+
+  it should "reset simTimeMs to 06:00 (21600000 ms)" in {
+    SimClock.reset()
+    SimClock.simTimeMs shouldBe 6L * 3600L * 1000L
+  }
+
+  it should "queue events with scheduleAt" in {
+    SimClock.reset()
+    val before = SimClock.queueSize
+    SimClock.scheduleAt(SimClock.simTimeMs + 1000L) { () => () }
+    SimClock.queueSize shouldBe (before + 1)
+    SimClock.reset() // cleans queue
+  }
+
+  it should "queue events with scheduleIn" in {
+    SimClock.reset()
+    SimClock.scheduleIn(5000L) { () => () }
+    SimClock.queueSize shouldBe 1
+    SimClock.reset()
+  }
+}
+
+
+class PathDebuggerSpec extends AnyFlatSpec with Matchers {
+
+  // Build the real graph once for all path tests
+  private lazy val graph = {
+    val metro  = scala.io.Source.fromFile("data/tramos.json").mkString
+    val paths  = new MetroParser(metro).parseMetro(metro)
+    val sorted = paths
+      .groupBy(_.features.numerolineausuario)
+      .map { case (line, ps) => line -> Path.sortLinePaths(ps) }
+    new Metro(sorted, 2000, 10).buildMetroGraph()
+  }
+
+  "PathDebugger.findPath" should "find a path between two valid stations" in {
+    val result = PathDebugger.findPath(graph, "EMPALME", "BATAN")
+    result should include ("\"found\":true")
+    result should include ("EMPALME")
+    result should include ("BATAN")
+  }
+
+  it should "return error for unknown origin" in {
+    val result = PathDebugger.findPath(graph, "NOWHERE_XYZ", "BATAN")
+    result should include ("\"found\":false")
+    result should include ("Station not found")
+  }
+
+  it should "return error for unknown destination" in {
+    val result = PathDebugger.findPath(graph, "EMPALME", "NOWHERE_XYZ")
+    result should include ("\"found\":false")
+    result should include ("Station not found")
+  }
+
+  it should "return error when origin and destination are the same" in {
+    val result = PathDebugger.findPath(graph, "EMPALME", "EMPALME")
+    result should include ("\"found\":false")
+    result should include ("same node")
+  }
+
+  it should "include platform nodes in the result" in {
+    val result = PathDebugger.findPath(graph, "EMPALME", "BATAN")
+    result should include ("platform")
+  }
+}

--- a/metro/karma.conf.js
+++ b/metro/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function (config) {
       subdir: '.',
       reporters: [
         { type: 'html' },
+        { type: 'lcovonly', file: 'lcov.info' },
         { type: 'text-summary' }
       ]
     },

--- a/metro/src/app/services/simulation-state.service.spec.ts
+++ b/metro/src/app/services/simulation-state.service.spec.ts
@@ -9,6 +9,8 @@ describe('SimulationStateService', () => {
     service = TestBed.inject(SimulationStateService);
   });
 
+  // ── creation ─────────────────────────────────────────────────────────────
+
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
@@ -19,7 +21,14 @@ describe('SimulationStateService', () => {
     expect(service.metroPeople).toBe(0);
     expect(service.trainsPeople).toBe(0);
     expect(service.dirty).toBeFalse();
+    expect(service.paused).toBeTrue();
   });
+
+  it('getTrain should return undefined for unknown id', () => {
+    expect(service.getTrain('UNKNOWN')).toBeUndefined();
+  });
+
+  // ── initLines ────────────────────────────────────────────────────────────
 
   it('initLines should populate platformsPeople and stationsPeople', () => {
     service.initLines(['1', '2', '3']);
@@ -28,12 +37,53 @@ describe('SimulationStateService', () => {
     expect(service.stationsPeople.get('3')).toBe(0);
   });
 
+  // ── reset ────────────────────────────────────────────────────────────────
+
+  it('reset should clear trains and set dirty', () => {
+    service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
+    service.reset();
+    expect(service.trains.length).toBe(0);
+    expect(service.dirty).toBeTrue();
+  });
+
+  it('reset should clear people counts', () => {
+    service.process({ message: 'peopleInMetro', people: 500 });
+    service.reset();
+    expect(service.metroPeople).toBe(0);
+    expect(service.simulationPeople).toBe(0);
+  });
+
+  it('reset should clear tracked person', () => {
+    service.trackedPersonId = 'p1';
+    service.trackedPersonNodes = ['A', 'B'];
+    service.reset();
+    expect(service.trackedPersonId).toBeNull();
+    expect(service.trackedPersonNodes).toEqual([]);
+  });
+
+  // ── newTrain ─────────────────────────────────────────────────────────────
+
   it('process newTrain should add a train and set dirty', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 100, y: 200 });
     expect(service.trains.length).toBe(1);
     expect(service.trains[0].id).toBe('T1');
     expect(service.dirty).toBeTrue();
   });
+
+  it('process newTrain should upsert when train already exists', () => {
+    service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
+    service.process({ message: 'newTrain', train: 'T1', x: 100, y: 200 });
+    expect(service.trains.length).toBe(1);
+    expect(service.getTrain('T1')!.targetX).toBe(100);
+  });
+
+  it('getTrain should return train after newTrain', () => {
+    service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
+    expect(service.getTrain('T1')).toBeDefined();
+    expect(service.getTrain('T1')!.id).toBe('T1');
+  });
+
+  // ── moveTrain ────────────────────────────────────────────────────────────
 
   it('process moveTrain should update target position and set dirty', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
@@ -49,6 +99,17 @@ describe('SimulationStateService', () => {
     expect(service.dirty).toBeFalse();
   });
 
+  // ── removeTrain ──────────────────────────────────────────────────────────
+
+  it('process removeTrain should remove the train', () => {
+    service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
+    service.process({ message: 'removeTrain', train: 'T1' });
+    expect(service.trains.length).toBe(0);
+    expect(service.dirty).toBeTrue();
+  });
+
+  // ── people counts ─────────────────────────────────────────────────────────
+
   it('process peopleInLinePlatforms should update platformsPeople', () => {
     service.initLines(['1']);
     service.process({ message: 'peopleInLinePlatforms', line: 'L1', people: 42 });
@@ -59,6 +120,16 @@ describe('SimulationStateService', () => {
     service.initLines(['2']);
     service.process({ message: 'peopleInLineStations', line: 'L2', people: 17 });
     expect(service.stationsPeople.get('2')).toBe(17);
+  });
+
+  it('process peopleInPlatform should update andenPeople', () => {
+    service.process({ message: 'peopleInPlatform', anden: 42, people: 15 });
+    expect(service.andenPeople.get(42)).toBe(15);
+  });
+
+  it('process peopleInStation should update stationIdPeople', () => {
+    service.process({ message: 'peopleInStation', stationId: 'Station_X_1', people: 7 });
+    expect(service.stationIdPeople.get('Station_X_1')).toBe(7);
   });
 
   it('process peopleInTrains should update trainsPeople', () => {
@@ -76,8 +147,109 @@ describe('SimulationStateService', () => {
     expect(service.simulationPeople).toBe(1000);
   });
 
+  // ── simulation state ──────────────────────────────────────────────────────
+
   it('process timeMultiplier should update timeMultiplier', () => {
     service.process({ message: 'timeMultiplier', multiplier: 5 });
     expect(service.timeMultiplier).toBe(5);
+  });
+
+  it('process simPaused should update paused state', () => {
+    service.process({ message: 'simPaused', paused: false });
+    expect(service.paused).toBeFalse();
+    service.process({ message: 'simPaused', paused: true });
+    expect(service.paused).toBeTrue();
+  });
+
+  it('process simLoad should update load metrics', () => {
+    service.process({ message: 'simLoad', load: 0.75, eventsPerTick: 12, queueSize: 3 });
+    expect(service.simLoad).toBe(0.75);
+    expect(service.eventsPerTick).toBe(12);
+    expect(service.queueSize).toBe(3);
+  });
+
+  // ── persons ──────────────────────────────────────────────────────────────
+
+  it('process personsInTrain should update personsInTrain list', () => {
+    service.process({ message: 'personsInTrain', train: 'T1', persons: [{ id: 'p1', destination: 'X' }] });
+    expect(service.personsInTrain.length).toBe(1);
+    expect(service.personsInTrain[0].id).toBe('p1');
+  });
+
+  it('process personsInPlatform should store persons keyed by anderId', () => {
+    service.process({ message: 'personsInPlatform', anderId: '42', persons: [{ id: 'p1', destination: 'Y' }] });
+    expect(service.personsInPlatform.get('42')).toBeDefined();
+    expect(service.personsInPlatform.get('42')![0].id).toBe('p1');
+  });
+
+  // ── person tracking ───────────────────────────────────────────────────────
+
+  it('process personPath should update nodes when person matches', () => {
+    service.trackedPersonId = 'p1';
+    service.process({ message: 'personPath', person: 'p1', nodes: ['A', 'B', 'C'] });
+    expect(service.trackedPersonNodes).toEqual(['A', 'B', 'C']);
+  });
+
+  it('process personPath should NOT update nodes when person does not match', () => {
+    service.trackedPersonId = 'p1';
+    service.process({ message: 'personPath', person: 'p2', nodes: ['X'] });
+    expect(service.trackedPersonNodes).toEqual([]);
+  });
+
+  it('process personLocation should update location when person matches', () => {
+    service.trackedPersonId = 'p1';
+    service.process({ message: 'personLocation', person: 'p1', locType: 'station', locId: 'S1' });
+    expect(service.trackedPersonLocType).toBe('station');
+    expect(service.trackedPersonLocId).toBe('S1');
+  });
+
+  it('process personLocation should NOT update when person does not match', () => {
+    service.trackedPersonId = 'p1';
+    service.process({ message: 'personLocation', person: 'p2', locType: 'platform', locId: 'P1' });
+    expect(service.trackedPersonLocType).toBe('');
+  });
+
+  // ── path query ────────────────────────────────────────────────────────────
+
+  it('process pathResult should store the result', () => {
+    service.process({ message: 'pathResult', found: true, from: 'A', to: 'B', nodes: [] });
+    expect(service.pathQueryResult).not.toBeNull();
+    expect(service.pathQueryResult!.found).toBeTrue();
+  });
+
+  it('pathQuerySummary should return empty string when no result', () => {
+    expect(service.pathQuerySummary()).toBe('');
+  });
+
+  it('pathQuerySummary should describe a not-found result', () => {
+    service.process({ message: 'pathResult', found: false, from: 'A', to: 'B', error: 'Station not found: B', nodes: [] });
+    expect(service.pathQuerySummary()).toContain('not found');
+  });
+
+  it('pathQuerySummary should describe a found result with node count', () => {
+    service.process({ message: 'pathResult', found: true, from: 'EMPALME', to: 'BATAN', nodes: [
+      { kind: 'station', id: 'S1', label: 'EMPALME', line: '10a' },
+      { kind: 'platform', id: 'P1', label: 'Platform 420', line: '10a' },
+      { kind: 'station', id: 'S2', label: 'BATAN', line: '10a' },
+    ]});
+    const summary = service.pathQuerySummary();
+    expect(summary).toContain('3 nodes');
+    expect(summary).toContain('EMPALME');
+  });
+
+  it('queryPath should send a queryPath message via ws', () => {
+    const wsSpy = { send: jasmine.createSpy('send') };
+    service.queryPath(wsSpy, 'EMPALME', 'BATAN');
+    expect(wsSpy.send).toHaveBeenCalledWith({ message: 'queryPath', from: 'EMPALME', to: 'BATAN' });
+  });
+
+  // ── overcrowding ──────────────────────────────────────────────────────────
+
+  it('process platformOvercrowded should not throw', () => {
+    expect(() => service.process({ message: 'platformOvercrowded', platform: 'P1', people: 600 })).not.toThrow();
+  });
+
+  it('process stationOvercrowded should not throw', () => {
+    expect(() => service.process({ message: 'stationOvercrowded', platform: 'S1', people: 1000 })).not.toThrow();
   });
 });

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -19,6 +19,7 @@ describe('TrainComponent', () => {
   const mockMetroDataService = {
     stations: [],
     paths: [],
+    lineDestinations: new Map<string, string>(),
   };
   const mockSimulationStateService = {
     trains: [],
@@ -27,10 +28,15 @@ describe('TrainComponent', () => {
     trainsPeople: 0,
     timeMultiplier: 1,
     dirty: false,
+    paused: true,
     platformsPeople: new Map<string, number>(),
     stationsPeople: new Map<string, number>(),
+    andenPeople: new Map<number, number>(),
+    stationIdPeople: new Map<string, number>(),
+    trackedPersonId: null,
     initLines: jasmine.createSpy('initLines'),
     process: jasmine.createSpy('process'),
+    getTrain: jasmine.createSpy('getTrain'),
   };
 
   beforeEach(async () => {
@@ -60,10 +66,95 @@ describe('TrainComponent', () => {
     expect(component.currentScale).toBeGreaterThan(0);
   });
 
+  // ── displayClock ─────────────────────────────────────────────────────────
+
   it('displayClock should return a time string', () => {
-    const clock = component.displayClock();
-    expect(clock).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    expect(component.displayClock()).toMatch(/^\d{2}:\d{2}:\d{2}$/);
   });
+
+  it('displayClock should format midnight correctly', () => {
+    (component as any).time = 0;
+    expect(component.displayClock()).toBe('00:00:00');
+  });
+
+  it('displayClock should format noon correctly', () => {
+    (component as any).time = 12 * 3600 * 1000;
+    expect(component.displayClock()).toBe('12:00:00');
+  });
+
+  it('displayClock should format 23:59:59 correctly', () => {
+    (component as any).time = (23 * 3600 + 59 * 60 + 59) * 1000;
+    expect(component.displayClock()).toBe('23:59:59');
+  });
+
+  // ── peakLabel ────────────────────────────────────────────────────────────
+
+  it('peakLabel should return PEAK·AM during morning rush', () => {
+    (component as any).time = 8 * 3600 * 1000;
+    expect(component.peakLabel).toBe('PEAK · AM');
+  });
+
+  it('peakLabel should return PEAK·PM during evening rush', () => {
+    (component as any).time = 18 * 3600 * 1000;
+    expect(component.peakLabel).toBe('PEAK · PM');
+  });
+
+  it('peakLabel should return NIGHT after midnight', () => {
+    (component as any).time = 2 * 3600 * 1000;
+    expect(component.peakLabel).toBe('NIGHT');
+  });
+
+  it('peakLabel should return OFF·PEAK at midday', () => {
+    (component as any).time = 13 * 3600 * 1000;
+    expect(component.peakLabel).toBe('OFF · PEAK');
+  });
+
+  // ── fmtCount ─────────────────────────────────────────────────────────────
+
+  it('fmtCount should return string for small numbers', () => {
+    expect(component.fmtCount(0)).toBe('0');
+    expect(component.fmtCount(999)).toBe('999');
+  });
+
+  it('fmtCount should format numbers >= 1000 with k', () => {
+    expect(component.fmtCount(1000)).toBe('1.00k');
+    expect(component.fmtCount(5500)).toBe('5.50k');
+  });
+
+  it('fmtCount should format numbers >= 10000 with one decimal k', () => {
+    expect(component.fmtCount(10000)).toBe('10.0k');
+    expect(component.fmtCount(25600)).toBe('25.6k');
+  });
+
+  // ── sparklinePoints ──────────────────────────────────────────────────────
+
+  it('sparklinePoints should return a non-empty string', () => {
+    const result = component.sparklinePoints([10, 20, 30, 20, 10]);
+    expect(typeof result).toBe('string');
+    expect(result.length).toBeGreaterThan(0);
+  });
+
+  it('sparklinePoints should handle all-zero values without throwing', () => {
+    expect(() => component.sparklinePoints(Array(40).fill(0))).not.toThrow();
+  });
+
+  it('sparklinePoints point count matches input length', () => {
+    const values = [1, 2, 3, 4, 5];
+    const points = component.sparklinePoints(values).split(' ');
+    expect(points.length).toBe(5);
+  });
+
+  // ── lineColors ───────────────────────────────────────────────────────────
+
+  it('lineColors should return a color string for known lines', () => {
+    expect(component.lineColors('1')).toBeTruthy();
+  });
+
+  it('lineColors should return a fallback color for unknown lines', () => {
+    expect(component.lineColors('999')).toBeTruthy();
+  });
+
+  // ── linePeople / allPeople ───────────────────────────────────────────────
 
   it('linePeople should return entries sorted by line name', () => {
     mockSimulationStateService.platformsPeople.set('2', 30);
@@ -74,21 +165,64 @@ describe('TrainComponent', () => {
   });
 
   it('allPeople should sum map values', () => {
-    const map = new Map([['a', 5], ['b', 3]]);
-    expect(component.allPeople(map)).toBe(8);
+    expect(component.allPeople(new Map([['a', 5], ['b', 3]]))).toBe(8);
   });
 
   it('allPeople should return 0 for empty map', () => {
     expect(component.allPeople(new Map())).toBe(0);
   });
 
-  it('lineColors should return a color string for known lines', () => {
-    expect(component.lineColors('1')).toBeTruthy();
-    expect(component.lineColors('1')).not.toBe('');
+  // ── linePercent ──────────────────────────────────────────────────────────
+
+  it('linePercent should return 100 for the maximum value', () => {
+    mockSimulationStateService.platformsPeople.clear();
+    mockSimulationStateService.platformsPeople.set('1', 50);
+    expect(component.linePercent(50)).toBe(100);
   });
 
-  it('lineColors should return a fallback color for unknown lines', () => {
-    expect(component.lineColors('999')).toBeTruthy();
-    expect(component.lineColors('999')).not.toBe('');
+  it('linePercent should return 0 when count is 0', () => {
+    mockSimulationStateService.platformsPeople.clear();
+    expect(component.linePercent(0)).toBe(0);
+  });
+
+  // ── telemetry getters ────────────────────────────────────────────────────
+
+  it('telemetryStations should return station count', () => {
+    expect(component.telemetryStations).toBe(0);
+  });
+
+  it('telemetrySegments should return path count', () => {
+    expect(component.telemetrySegments).toBe(0);
+  });
+
+  it('telemetryTrains should return train count', () => {
+    expect(component.telemetryTrains).toBe(0);
+  });
+
+  it('zoomReadout should contain ×', () => {
+    expect(component.zoomReadout).toContain('×');
+  });
+
+  // ── toggleShowAllPanels ──────────────────────────────────────────────────
+
+  it('toggleShowAllPanels first click should set showAllPanels to true', () => {
+    component.toggleShowAllPanels();
+    expect(component.showAllPanels).toBeTrue();
+    expect((component as any).stationsHidden).toBeFalse();
+  });
+
+  it('toggleShowAllPanels second click should hide all and set stationsHidden', () => {
+    component.toggleShowAllPanels();
+    component.toggleShowAllPanels();
+    expect(component.showAllPanels).toBeFalse();
+    expect((component as any).stationsHidden).toBeTrue();
+  });
+
+  it('toggleShowAllPanels third click should show all again', () => {
+    component.toggleShowAllPanels();
+    component.toggleShowAllPanels();
+    component.toggleShowAllPanels();
+    expect(component.showAllPanels).toBeTrue();
+    expect((component as any).stationsHidden).toBeFalse();
   });
 });

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -33,6 +33,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   private _mouseContainerX    = -1;
   private _mouseContainerY    = -1;
   showAllPanels = false;
+  private stationsHidden = false;
 
   private ctxTiles!: CanvasRenderingContext2D;
   private ctxStations!: CanvasRenderingContext2D;
@@ -478,17 +479,25 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   toggleShowAllPanels(): void {
-    this.showAllPanels = !this.showAllPanels;
+    if (!this.showAllPanels) {
+      this.showAllPanels   = true;
+      this.stationsHidden  = false;
+    } else {
+      this.showAllPanels   = false;
+      this.stationsHidden  = true;
+    }
     this.applyOverlayClasses();
   }
 
   private applyOverlayClasses(): void {
     const el = this.stationsOverlay?.nativeElement as HTMLElement | undefined;
     if (!el) return;
-    const fitMul = this.currentScale / this.fitScale;
-    el.classList.toggle('show-interchange', fitMul > 1.05 || this.showAllPanels);
-    el.classList.toggle('show-all',         fitMul > 1.7  || this.showAllPanels);
-    el.classList.toggle('show-panel',       fitMul > 15   || this.showAllPanels);
+    const fitMul    = this.currentScale / this.fitScale;
+    const forceShow = this.showAllPanels;
+    const forceHide = this.stationsHidden;
+    el.classList.toggle('show-interchange', !forceHide && (fitMul > 1.05 || forceShow));
+    el.classList.toggle('show-all',         !forceHide && (fitMul > 1.7  || forceShow));
+    el.classList.toggle('show-panel',       !forceHide && (fitMul > 15   || forceShow));
     el.classList.toggle('zoom-deep',        fitMul > 7);
   }
 


### PR DESCRIPTION
## Botón mostrar/ocultar estaciones

**Problema:** al hacer click en «OCULTAR TODOS» estando con zoom > 1.7×, las estaciones permanecían visibles porque `fitMul > 1.7` seguía añadiendo la clase `show-all`, y `showAllPanels=false` no era suficiente para anularlo.

**Fix:** se añade `stationsHidden: boolean`. El botón alterna entre dos estados explícitos:
- Click en «MOSTRAR TODOS» → `showAllPanels=true`, `stationsHidden=false` → fuerza mostrar todo
- Click en «OCULTAR TODOS» → `showAllPanels=false`, `stationsHidden=true` → fuerza ocultar todo (anula zoom)

`applyOverlayClasses()` respeta `forceHide` en los tres toggles, y el comportamiento por defecto (zoom-based) se mantiene igual al arrancar.

## Cobertura en CI

- `karma.conf.js`: añadido reporter `lcovonly` (genera `lcov.info` para tooling externo)
- CI: flag `--code-coverage` en el paso de test; nuevo paso `Upload coverage report` sube el directorio `coverage/metro/` como artefacto con retención de 30 días
- El resumen de cobertura (`text-summary`) se imprime al final del log del job

Cobertura actual: **Statements 22% · Branches 10% · Functions 19% · Lines 24%**

## Test plan
- [ ] 40/40 tests con `--code-coverage` ✓
- [ ] Verificar que «OCULTAR TODOS» oculta estaciones en zoom alto
- [ ] Verificar que «MOSTRAR TODOS» muestra estaciones en zoom bajo
- [ ] Artefacto `coverage-report` visible en el job de CI