### PR TITLE
[FIX] Train panel real-time updates, capacity, speed and UX fixes

### DIFF
--- a/metro/src/app/train/train-panel/train-panel.component.ts
+++ b/metro/src/app/train/train-panel/train-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 
 import { LINE_COLORS } from '../../constants';
 import { Train } from '../../train';
@@ -8,7 +8,6 @@ import { WebSocketService } from '../../services/websocket.service';
 
 @Component({
   selector: 'app-train-panel',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './train-panel.component.html',
   styleUrls: ['./train-panel.component.css'],
   host: {

--- a/metro/src/app/train/train.component.css
+++ b/metro/src/app/train/train.component.css
@@ -100,6 +100,7 @@
 .station-labels {
   position: absolute;
   inset: 0;
+  overflow: hidden;
   pointer-events: none;
   z-index: 6;
   font-family: var(--mono);

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -162,6 +162,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
               train.pathSegStart  = segStart;
               train.pathSegEnd    = segEnd;
               train.line = seg.line;
+              train.capacity = (TRAIN_WAGONS[seg.line] ?? DEFAULT_WAGONS) * this.cfg.config.wagonCapacity;
               const last = path[path.length - 1];
               const prev = path[path.length - 2];
               train.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
@@ -800,13 +801,20 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
       }
       const locPos = this.resolveLocToPos();
       if (locPos) {
+        const r = 7 / this.currentScale;
         ctx.save();
-        ctx.beginPath();
-        ctx.arc(locPos.x, locPos.y, 5 / this.currentScale, 0, Math.PI * 2);
-        ctx.fillStyle = '#ef4444';
-        ctx.fill();
+        ctx.fillStyle   = '#ef4444';
         ctx.strokeStyle = '#fff';
-        ctx.lineWidth = 1.2 / this.currentScale;
+        ctx.lineWidth   = 1.2 / this.currentScale;
+        // head
+        ctx.beginPath();
+        ctx.arc(locPos.x, locPos.y - r * 1.05, r * 0.52, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.stroke();
+        // body (shoulder arc)
+        ctx.beginPath();
+        ctx.arc(locPos.x, locPos.y + r * 0.75, r, Math.PI, 0);
+        ctx.fill();
         ctx.stroke();
         ctx.restore();
       }
@@ -1021,8 +1029,20 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   // ── Speed ────────────────────────────────────────────────────
 
   onSpeedChange(idx: number): void {
+    const oldSpeed = this.localSpeed;
     this.speedIdx = idx;
-    this.wsService.send({ message: 'setSpeed', factor: this.localSpeed });
+    const newSpeed = this.localSpeed;
+    const now = performance.now();
+    const ratio = oldSpeed / newSpeed;
+    for (const train of this.state.trains) {
+      if (train.travelMs > 0) {
+        const elapsed = now - train.departedAt;
+        if (elapsed < train.travelMs) {
+          train.travelMs = elapsed + (train.travelMs - elapsed) * ratio;
+        }
+      }
+    }
+    this.wsService.send({ message: 'setSpeed', factor: newSpeed });
   }
 
   // ── Simulation controls ───────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Ocupación en tiempo real**: `TrainPanelComponent` tenía `OnPush` y recibía siempre la misma referencia al objeto `Train` (mutado in-place), por lo que Angular nunca detectaba el cambio. Eliminado `OnPush` → ahora se actualiza en cada ciclo de CD disparado por el padre.
- **Capacidad correcta**: calculada como `TRAIN_WAGONS[línea] × cfg.wagonCapacity`, alineada con el valor configurable del panel de control. Antes se usaba el valor hardcodeado `1000` del simulador Scala (igual para todas las líneas).
- **Cambio de velocidad inmediato**: al cambiar el multiplicador de velocidad, se reescala el `travelMs` de los trenes en vuelo proporcionalmente, evitando el efecto extraño de trenes que no aceleran/frenan hasta el siguiente mensaje del simulador.
- **Buddy marker**: el punto rojo del pasajero seguido se sustituye por una silueta de persona (cabeza + arco de hombros), escalada con el zoom.
- **Paneles de estación en zoom extremo**: añadido `overflow: hidden` a `.station-labels` para que los paneles de estaciones fuera del viewport no desborden al área visible.

## Test plan

- [ ] Seleccionar un tren y verificar que el número de ocupados cambia en tiempo real
- [ ] Cambiar `WAGON CAP.` en el panel y verificar que la capacidad del tren se actualiza
- [ ] Cambiar la velocidad de simulación y verificar que los trenes aceleran/frenan inmediatamente
- [ ] Seguir un pasajero y verificar que aparece el buddy en su posición
- [ ] Hacer zoom extremo y verificar que no aparecen paneles de estaciones fuera del viewport