### PR TITLE
[Refactor F2] SimulationStateService con signals + WebSocketService share

### DIFF
--- a/metro/src/app/debug/debug.component.html
+++ b/metro/src/app/debug/debug.component.html
@@ -43,7 +43,7 @@
   </section>
 
   <!-- ── Result ─────────────────────────────────────────────────────── -->
-  @if (state.pathQueryResult; as r) {
+  @if (state.pathQueryResult(); as r) {
     <section class="result" [ngClass]="r.found ? 'found' : 'not-found'">
 
       <!-- status bar -->

--- a/metro/src/app/debug/debug.component.ts
+++ b/metro/src/app/debug/debug.component.ts
@@ -22,16 +22,14 @@ export class DebugComponent {
     readonly state: SimulationStateService,
   ) {}
 
-  /** Send a queryPath request to the backend. */
   query(): void {
     if (this.from.trim() && this.to.trim()) {
-      this.state.queryPath(this.ws, this.from.trim(), this.to.trim());
+      this.ws.queryPath(this.from.trim(), this.to.trim());
     }
   }
 
-  /** Separate the returned nodes into station-only rows for the summary line. */
   stationLabels(): string {
-    const r = this.state.pathQueryResult;
+    const r = this.state.pathQueryResult();
     if (!r?.found) return '';
     return r.nodes
       .filter((n: PathNode) => n.kind === 'station')

--- a/metro/src/app/header/header.component.html
+++ b/metro/src/app/header/header.component.html
@@ -11,8 +11,8 @@
   <div class="topbar-center">
     <div class="topbar-meta"><span>NODE</span><span class="v">MAD-001</span></div>
     <div class="topbar-meta"><span>SESSION</span><span class="v">{{ sessionId }}</span></div>
-    <div class="topbar-meta"><span>TICK</span><span class="v">{{ state.paused ? 'HOLD' : 'LIVE' }}</span></div>
-    <div class="topbar-meta"><span>×</span><span class="v">{{ state.timeMultiplier.toFixed(2) }}</span></div>
+    <div class="topbar-meta"><span>TICK</span><span class="v">{{ state.paused() ? 'HOLD' : 'LIVE' }}</span></div>
+    <div class="topbar-meta"><span>×</span><span class="v">{{ state.timeMultiplier().toFixed(2) }}</span></div>
   </div>
 
   <nav class="topbar-nav">

--- a/metro/src/app/services/simulation-state.service.spec.ts
+++ b/metro/src/app/services/simulation-state.service.spec.ts
@@ -16,12 +16,11 @@ describe('SimulationStateService', () => {
   });
 
   it('should start with empty state', () => {
-    expect(service.trains.length).toBe(0);
-    expect(service.simulationPeople).toBe(0);
-    expect(service.metroPeople).toBe(0);
-    expect(service.trainsPeople).toBe(0);
-    expect(service.dirty).toBeFalse();
-    expect(service.paused).toBeTrue();
+    expect(service.trains().length).toBe(0);
+    expect(service.simulationPeople()).toBe(0);
+    expect(service.metroPeople()).toBe(0);
+    expect(service.trainsPeople()).toBe(0);
+    expect(service.paused()).toBeTrue();
   });
 
   it('getTrain should return undefined for unknown id', () => {
@@ -32,48 +31,44 @@ describe('SimulationStateService', () => {
 
   it('initLines should populate platformsPeople and stationsPeople', () => {
     service.initLines(['1', '2', '3']);
-    expect(service.platformsPeople.get('1')).toBe(0);
-    expect(service.platformsPeople.get('2')).toBe(0);
-    expect(service.stationsPeople.get('3')).toBe(0);
+    expect(service.platformsPeople().get('1')).toBe(0);
+    expect(service.platformsPeople().get('2')).toBe(0);
+    expect(service.stationsPeople().get('3')).toBe(0);
   });
 
   // ── reset ────────────────────────────────────────────────────────────────
 
-  it('reset should clear trains and set dirty', () => {
+  it('reset should clear trains', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.reset();
-    expect(service.trains.length).toBe(0);
-    expect(service.dirty).toBeTrue();
+    expect(service.trains().length).toBe(0);
   });
 
   it('reset should clear people counts', () => {
     service.process({ message: 'peopleInMetro', people: 500 });
     service.reset();
-    expect(service.metroPeople).toBe(0);
-    expect(service.simulationPeople).toBe(0);
+    expect(service.metroPeople()).toBe(0);
+    expect(service.simulationPeople()).toBe(0);
   });
 
   it('reset should clear tracked person', () => {
-    service.trackedPersonId = 'p1';
-    service.trackedPersonNodes = ['A', 'B'];
+    service.trackPerson('p1');
     service.reset();
-    expect(service.trackedPersonId).toBeNull();
-    expect(service.trackedPersonNodes).toEqual([]);
+    expect(service.tracked()).toBeNull();
   });
 
   // ── newTrain ─────────────────────────────────────────────────────────────
 
-  it('process newTrain should add a train and set dirty', () => {
+  it('process newTrain should add a train', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 100, y: 200 });
-    expect(service.trains.length).toBe(1);
-    expect(service.trains[0].id).toBe('T1');
-    expect(service.dirty).toBeTrue();
+    expect(service.trains().length).toBe(1);
+    expect(service.trains()[0].id).toBe('T1');
   });
 
   it('process newTrain should upsert when train already exists', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.process({ message: 'newTrain', train: 'T1', x: 100, y: 200 });
-    expect(service.trains.length).toBe(1);
+    expect(service.trains().length).toBe(1);
     expect(service.getTrain('T1')!.targetX).toBe(100);
   });
 
@@ -85,18 +80,16 @@ describe('SimulationStateService', () => {
 
   // ── moveTrain ────────────────────────────────────────────────────────────
 
-  it('process moveTrain should update target position and set dirty', () => {
+  it('process moveTrain should update target position', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
-    service.dirty = false;
     service.process({ message: 'moveTrain', train: 'T1', x: 50, y: 75 });
-    expect(service.trains[0].targetX).toBe(50);
-    expect(service.trains[0].targetY).toBe(75);
-    expect(service.dirty).toBeTrue();
+    expect(service.trains()[0].targetX).toBe(50);
+    expect(service.trains()[0].targetY).toBe(75);
   });
 
-  it('process moveTrain for unknown train should not set dirty', () => {
+  it('process moveTrain for unknown train should not add it', () => {
     service.process({ message: 'moveTrain', train: 'UNKNOWN', x: 50, y: 75 });
-    expect(service.dirty).toBeFalse();
+    expect(service.trains().length).toBe(0);
   });
 
   // ── removeTrain ──────────────────────────────────────────────────────────
@@ -104,8 +97,7 @@ describe('SimulationStateService', () => {
   it('process removeTrain should remove the train', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.process({ message: 'removeTrain', train: 'T1' });
-    expect(service.trains.length).toBe(0);
-    expect(service.dirty).toBeTrue();
+    expect(service.trains().length).toBe(0);
   });
 
   // ── people counts ─────────────────────────────────────────────────────────
@@ -113,108 +105,121 @@ describe('SimulationStateService', () => {
   it('process peopleInLinePlatforms should update platformsPeople', () => {
     service.initLines(['1']);
     service.process({ message: 'peopleInLinePlatforms', line: 'L1', people: 42 });
-    expect(service.platformsPeople.get('1')).toBe(42);
+    expect(service.platformsPeople().get('1')).toBe(42);
   });
 
   it('process peopleInLineStations should update stationsPeople', () => {
     service.initLines(['2']);
     service.process({ message: 'peopleInLineStations', line: 'L2', people: 17 });
-    expect(service.stationsPeople.get('2')).toBe(17);
+    expect(service.stationsPeople().get('2')).toBe(17);
   });
 
   it('process peopleInPlatform should update andenPeople', () => {
     service.process({ message: 'peopleInPlatform', anden: 42, people: 15 });
-    expect(service.andenPeople.get(42)).toBe(15);
+    expect(service.andenPeople().get(42)).toBe(15);
   });
 
   it('process peopleInStation should update stationIdPeople', () => {
     service.process({ message: 'peopleInStation', stationId: 'Station_X_1', people: 7 });
-    expect(service.stationIdPeople.get('Station_X_1')).toBe(7);
+    expect(service.stationIdPeople().get('Station_X_1')).toBe(7);
   });
 
   it('process peopleInTrains should update trainsPeople', () => {
     service.process({ message: 'peopleInTrains', people: 99 });
-    expect(service.trainsPeople).toBe(99);
+    expect(service.trainsPeople()).toBe(99);
   });
 
   it('process peopleInMetro should update metroPeople', () => {
     service.process({ message: 'peopleInMetro', people: 500 });
-    expect(service.metroPeople).toBe(500);
+    expect(service.metroPeople()).toBe(500);
   });
 
   it('process peopleInSimulation should update simulationPeople', () => {
     service.process({ message: 'peopleInSimulation', people: 1000 });
-    expect(service.simulationPeople).toBe(1000);
+    expect(service.simulationPeople()).toBe(1000);
   });
 
   // ── simulation state ──────────────────────────────────────────────────────
 
   it('process timeMultiplier should update timeMultiplier', () => {
     service.process({ message: 'timeMultiplier', multiplier: 5 });
-    expect(service.timeMultiplier).toBe(5);
+    expect(service.timeMultiplier()).toBe(5);
   });
 
   it('process simPaused should update paused state', () => {
     service.process({ message: 'simPaused', paused: false });
-    expect(service.paused).toBeFalse();
+    expect(service.paused()).toBeFalse();
     service.process({ message: 'simPaused', paused: true });
-    expect(service.paused).toBeTrue();
+    expect(service.paused()).toBeTrue();
   });
 
   it('process simLoad should update load metrics', () => {
     service.process({ message: 'simLoad', load: 0.75, eventsPerTick: 12, queueSize: 3 });
-    expect(service.simLoad).toBe(0.75);
-    expect(service.eventsPerTick).toBe(12);
-    expect(service.queueSize).toBe(3);
+    expect(service.simLoad()).toBe(0.75);
+    expect(service.eventsPerTick()).toBe(12);
+    expect(service.queueSize()).toBe(3);
   });
 
   // ── persons ──────────────────────────────────────────────────────────────
 
   it('process personsInTrain should update personsInTrain list', () => {
     service.process({ message: 'personsInTrain', train: 'T1', persons: [{ id: 'p1', destination: 'X' }] });
-    expect(service.personsInTrain.length).toBe(1);
-    expect(service.personsInTrain[0].id).toBe('p1');
+    expect(service.personsInTrain().length).toBe(1);
+    expect(service.personsInTrain()[0].id).toBe('p1');
   });
 
   it('process personsInPlatform should store persons keyed by anderId', () => {
     service.process({ message: 'personsInPlatform', anderId: '42', persons: [{ id: 'p1', destination: 'Y' }] });
-    expect(service.personsInPlatform.get('42')).toBeDefined();
-    expect(service.personsInPlatform.get('42')![0].id).toBe('p1');
+    expect(service.personsInPlatform().get('42')).toBeDefined();
+    expect(service.personsInPlatform().get('42')![0].id).toBe('p1');
   });
 
   // ── person tracking ───────────────────────────────────────────────────────
 
+  it('trackPerson should set tracked id', () => {
+    service.trackPerson('p1');
+    expect(service.tracked()?.id).toBe('p1');
+    expect(service.tracked()?.nodes).toEqual([]);
+    expect(service.tracked()?.loc).toBeNull();
+  });
+
+  it('untrackPerson should clear tracked', () => {
+    service.trackPerson('p1');
+    service.untrackPerson();
+    expect(service.tracked()).toBeNull();
+  });
+
   it('process personPath should update nodes when person matches', () => {
-    service.trackedPersonId = 'p1';
+    service.trackPerson('p1');
     service.process({ message: 'personPath', person: 'p1', nodes: ['A', 'B', 'C'] });
-    expect(service.trackedPersonNodes).toEqual(['A', 'B', 'C']);
+    expect(service.tracked()?.nodes).toEqual(['A', 'B', 'C']);
   });
 
   it('process personPath should NOT update nodes when person does not match', () => {
-    service.trackedPersonId = 'p1';
+    service.trackPerson('p1');
     service.process({ message: 'personPath', person: 'p2', nodes: ['X'] });
-    expect(service.trackedPersonNodes).toEqual([]);
+    expect(service.tracked()?.nodes).toEqual([]);
   });
 
   it('process personLocation should update location when person matches', () => {
-    service.trackedPersonId = 'p1';
+    service.trackPerson('p1');
     service.process({ message: 'personLocation', person: 'p1', locType: 'station', locId: 'S1' });
-    expect(service.trackedPersonLocType).toBe('station');
-    expect(service.trackedPersonLocId).toBe('S1');
+    expect(service.tracked()?.loc?.type).toBe('station');
+    expect(service.tracked()?.loc?.id).toBe('S1');
   });
 
   it('process personLocation should NOT update when person does not match', () => {
-    service.trackedPersonId = 'p1';
+    service.trackPerson('p1');
     service.process({ message: 'personLocation', person: 'p2', locType: 'platform', locId: 'P1' });
-    expect(service.trackedPersonLocType).toBe('');
+    expect(service.tracked()?.loc).toBeNull();
   });
 
   // ── path query ────────────────────────────────────────────────────────────
 
   it('process pathResult should store the result', () => {
     service.process({ message: 'pathResult', found: true, from: 'A', to: 'B', nodes: [] });
-    expect(service.pathQueryResult).not.toBeNull();
-    expect(service.pathQueryResult!.found).toBeTrue();
+    expect(service.pathQueryResult()).not.toBeNull();
+    expect(service.pathQueryResult()!.found).toBeTrue();
   });
 
   it('pathQuerySummary should return empty string when no result', () => {
@@ -235,12 +240,6 @@ describe('SimulationStateService', () => {
     const summary = service.pathQuerySummary();
     expect(summary).toContain('3 nodes');
     expect(summary).toContain('EMPALME');
-  });
-
-  it('queryPath should call queryPath on ws with from/to', () => {
-    const wsSpy = { queryPath: jasmine.createSpy('queryPath') };
-    service.queryPath(wsSpy, 'EMPALME', 'BATAN');
-    expect(wsSpy.queryPath).toHaveBeenCalledWith('EMPALME', 'BATAN');
   });
 
   // ── overcrowding ──────────────────────────────────────────────────────────

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -1,135 +1,167 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal, computed } from '@angular/core';
 
 import { Train } from '../train';
-import { PathNode, PathResult, SimulationMessage } from '../messages';
+import { PathResult, SimulationMessage } from '../messages';
+import { pathQuerySummary } from '../utils/path-summary';
+
+export interface TrackedPerson {
+  id: string;
+  nodes: string[];
+  loc: { type: 'station' | 'platform' | 'train'; id: string } | null;
+}
 
 @Injectable({ providedIn: 'root' })
 export class SimulationStateService {
 
-  // Keyed by train ID so newTrain from a snapshot replay does an upsert, not a duplicate push
-  private readonly trainsMap = new Map<string, Train>();
-  get trains(): Train[] { return Array.from(this.trainsMap.values()); }
-  getTrain(id: string): Train | undefined { return this.trainsMap.get(id); }
+  // ── Trains ─────────────────────────────────────────────────────────────────
+  private readonly _trainsMap = new Map<string, Train>();
+  private readonly _trainsSignal = signal<ReadonlyMap<string, Train>>(new Map());
+  readonly trains = computed(() => Array.from(this._trainsSignal().values()));
 
-  dirty = false;
-  simulationPeople = 0;
-  metroPeople = 0;
-  trainsPeople = 0;
-  timeMultiplier = 1;
-  paused = true;
-  simLoad = 0;
-  eventsPerTick = 0;
-  queueSize = 0;
+  getTrain(id: string): Train | undefined { return this._trainsMap.get(id); }
 
-  readonly platformsPeople = new Map<string, number>();
-  readonly stationsPeople = new Map<string, number>();
-  readonly andenPeople = new Map<number, number>();
-  readonly stationIdPeople = new Map<string, number>();
+  // ── People counts ──────────────────────────────────────────────────────────
+  readonly simulationPeople = signal(0);
+  readonly metroPeople      = signal(0);
+  readonly trainsPeople     = signal(0);
+  readonly timeMultiplier   = signal(1);
 
-  personsInTrain: Array<{ id: string; destination: string }> = [];
-  readonly personsInPlatform = new Map<string, Array<{ id: string; destination: string }>>();
-  trackedPersonId: string | null = null;
-  trackedPersonNodes: string[] = [];
-  trackedPersonLocType = '';
-  trackedPersonLocId = '';
+  // ── Platform/station people ────────────────────────────────────────────────
+  private _platformsPeople  = new Map<string, number>();
+  private _stationsPeople   = new Map<string, number>();
+  private _andenPeople      = new Map<number, number>();
+  private _stationIdPeople  = new Map<string, number>();
 
-  // ── Path-query debug state ───────────────────────────────────────────────
-  // Populated when the backend answers a {"message":"queryPath",...} request.
-  // Bind to this in any debug panel that wants to display the result.
-  pathQueryResult: PathResult | null = null;
+  readonly platformsPeople  = signal<ReadonlyMap<string, number>>(new Map());
+  readonly stationsPeople   = signal<ReadonlyMap<string, number>>(new Map());
+  readonly andenPeople      = signal<ReadonlyMap<number, number>>(new Map());
+  readonly stationIdPeople  = signal<ReadonlyMap<string, number>>(new Map());
+
+  // ── Simulation status ──────────────────────────────────────────────────────
+  readonly paused       = signal(true);
+  readonly simLoad      = signal(0);
+  readonly eventsPerTick = signal(0);
+  readonly queueSize    = signal(0);
+
+  // ── Persons ────────────────────────────────────────────────────────────────
+  readonly personsInTrain = signal<Array<{ id: string; destination: string }>>([]);
+  private _personsInPlatform = new Map<string, Array<{ id: string; destination: string }>>();
+  readonly personsInPlatform = signal<ReadonlyMap<string, Array<{ id: string; destination: string }>>>(new Map());
+
+  // ── Person tracking ────────────────────────────────────────────────────────
+  readonly tracked = signal<TrackedPerson | null>(null);
+
+  // ── Path query ─────────────────────────────────────────────────────────────
+  readonly pathQueryResult = signal<PathResult | null>(null);
 
   initLines(lines: string[]): void {
     for (const line of lines) {
-      this.platformsPeople.set(line, 0);
-      this.stationsPeople.set(line, 0);
+      this._platformsPeople.set(line, 0);
+      this._stationsPeople.set(line, 0);
     }
+    this.platformsPeople.set(new Map(this._platformsPeople));
+    this.stationsPeople.set(new Map(this._stationsPeople));
+  }
+
+  trackPerson(id: string): void {
+    this.tracked.set({ id, nodes: [], loc: null });
+  }
+
+  untrackPerson(): void {
+    this.tracked.set(null);
   }
 
   reset(): void {
-    this.trainsMap.clear();
-    this.simulationPeople = 0;
-    this.metroPeople = 0;
-    this.trainsPeople = 0;
-    for (const key of this.platformsPeople.keys()) this.platformsPeople.set(key, 0);
-    for (const key of this.stationsPeople.keys()) this.stationsPeople.set(key, 0);
-    this.andenPeople.clear();
-    this.stationIdPeople.clear();
-    this.personsInTrain = [];
-    this.personsInPlatform.clear();
-    this.trackedPersonId = null;
-    this.trackedPersonNodes = [];
-    this.trackedPersonLocType = '';
-    this.trackedPersonLocId = '';
-    this.pathQueryResult = null;
-    this.dirty = true;
+    this._trainsMap.clear();
+    this._trainsSignal.set(new Map());
+    this.simulationPeople.set(0);
+    this.metroPeople.set(0);
+    this.trainsPeople.set(0);
+    for (const key of this._platformsPeople.keys()) this._platformsPeople.set(key, 0);
+    for (const key of this._stationsPeople.keys()) this._stationsPeople.set(key, 0);
+    this.platformsPeople.set(new Map(this._platformsPeople));
+    this.stationsPeople.set(new Map(this._stationsPeople));
+    this._andenPeople.clear();
+    this.andenPeople.set(new Map());
+    this._stationIdPeople.clear();
+    this.stationIdPeople.set(new Map());
+    this.personsInTrain.set([]);
+    this._personsInPlatform.clear();
+    this.personsInPlatform.set(new Map());
+    this.tracked.set(null);
+    this.pathQueryResult.set(null);
   }
 
   process(msg: SimulationMessage): void {
     switch (msg.message) {
       case 'moveTrain': {
-        const train = this.trainsMap.get(msg.train);
+        const train = this._trainsMap.get(msg.train);
         if (train) {
           train.fromX = train.x;
           train.fromY = train.y;
           train.targetX = msg.x;
           train.targetY = msg.y;
           train.departedAt = performance.now();
-          train.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier;
+          train.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
           if (msg.anden    !== undefined) train.anden    = msg.anden;
-          this.dirty = true;
+          this._trainsSignal.set(new Map(this._trainsMap));
         }
         break;
       }
       case 'newTrain': {
-        const existing = this.trainsMap.get(msg.train);
+        const existing = this._trainsMap.get(msg.train);
         if (existing) {
           existing.fromX = existing.x;
           existing.fromY = existing.y;
           existing.targetX = msg.x;
           existing.targetY = msg.y;
           existing.departedAt = performance.now();
-          existing.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier;
+          existing.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
           if (msg.people   !== undefined) existing.people   = msg.people;
           if (msg.capacity !== undefined) existing.capacity = msg.capacity;
           if (msg.anden    !== undefined) existing.anden    = msg.anden;
         } else {
           const t = new Train(msg.train, msg.x, msg.y, msg.people ?? 0, msg.capacity ?? 600);
           if (msg.anden !== undefined) t.anden = msg.anden;
-          this.trainsMap.set(msg.train, t);
+          this._trainsMap.set(msg.train, t);
         }
-        this.dirty = true;
+        this._trainsSignal.set(new Map(this._trainsMap));
         break;
       }
       case 'removeTrain': {
-        this.trainsMap.delete(msg.train);
-        this.dirty = true;
+        this._trainsMap.delete(msg.train);
+        this._trainsSignal.set(new Map(this._trainsMap));
         break;
       }
       case 'peopleInLinePlatforms':
-        this.platformsPeople.set(msg.line.slice(1), msg.people);
+        this._platformsPeople.set(msg.line.slice(1), msg.people);
+        this.platformsPeople.set(new Map(this._platformsPeople));
         break;
       case 'peopleInLineStations':
-        this.stationsPeople.set(msg.line.slice(1), msg.people);
+        this._stationsPeople.set(msg.line.slice(1), msg.people);
+        this.stationsPeople.set(new Map(this._stationsPeople));
         break;
       case 'peopleInPlatform':
-        this.andenPeople.set(msg.anden, msg.people);
+        this._andenPeople.set(msg.anden, msg.people);
+        this.andenPeople.set(new Map(this._andenPeople));
         break;
       case 'peopleInStation':
-        this.stationIdPeople.set(msg.stationId, msg.people);
+        this._stationIdPeople.set(msg.stationId, msg.people);
+        this.stationIdPeople.set(new Map(this._stationIdPeople));
         break;
       case 'peopleInTrains':
-        this.trainsPeople = msg.people;
+        this.trainsPeople.set(msg.people);
         break;
       case 'peopleInMetro':
-        this.metroPeople = msg.people;
+        this.metroPeople.set(msg.people);
         break;
       case 'peopleInSimulation':
-        this.simulationPeople = msg.people;
+        this.simulationPeople.set(msg.people);
         break;
       case 'timeMultiplier':
-        this.timeMultiplier = msg.multiplier;
+        this.timeMultiplier.set(msg.multiplier);
         break;
       case 'platformOvercrowded':
         console.warn(`Platform overcrowded: ${msg.platform} with ${msg.people}`);
@@ -138,65 +170,39 @@ export class SimulationStateService {
         console.warn(`Station overcrowded: ${msg.platform} with ${msg.people}`);
         break;
       case 'simLoad':
-        this.simLoad = msg.load;
-        this.eventsPerTick = msg.eventsPerTick;
-        this.queueSize = msg.queueSize;
+        this.simLoad.set(msg.load);
+        this.eventsPerTick.set(msg.eventsPerTick);
+        this.queueSize.set(msg.queueSize);
         break;
       case 'simPaused':
-        this.paused = msg.paused;
+        this.paused.set(msg.paused);
         break;
       case 'personsInTrain':
-        this.personsInTrain = msg.persons;
+        this.personsInTrain.set(msg.persons);
         break;
       case 'personsInPlatform':
-        this.personsInPlatform.set(msg.anderId, msg.persons);
+        this._personsInPlatform.set(msg.anderId, msg.persons);
+        this.personsInPlatform.set(new Map(this._personsInPlatform));
         break;
-      case 'personPath':
-        if (msg.person === this.trackedPersonId) this.trackedPersonNodes = msg.nodes;
+      case 'personPath': {
+        const t = this.tracked();
+        if (t && msg.person === t.id) this.tracked.set({ ...t, nodes: msg.nodes });
         break;
-      case 'personLocation':
-        if (msg.person === this.trackedPersonId) {
-          this.trackedPersonLocType = msg.locType;
-          this.trackedPersonLocId  = msg.locId;
+      }
+      case 'personLocation': {
+        const t = this.tracked();
+        if (t && msg.person === t.id) {
+          this.tracked.set({ ...t, loc: { type: msg.locType, id: msg.locId } });
         }
         break;
+      }
       case 'pathResult':
-        this.pathQueryResult = msg;
+        this.pathQueryResult.set(msg);
         break;
     }
   }
 
-  /**
-   * Send a path query to the backend.
-   * The result will be stored in `pathQueryResult` once the backend responds.
-   *
-   * Usage in a component that has injected `WebSocketService`:
-   *   wsService.send({ message: 'queryPath', from: 'EMPALME', to: 'BATAN' });
-   *
-   * The helper below accepts partial, case-insensitive station names
-   * (the backend matches by substring on the denominacion field).
-   *
-   * @param ws    The injected WebSocketService instance.
-   * @param from  Origin station name (partial, case-insensitive), e.g. "empalme".
-   * @param to    Destination station name (partial, case-insensitive), e.g. "batan".
-   */
-  queryPath(ws: { queryPath(from: string, to: string): void }, from: string, to: string): void {
-    ws.queryPath(from, to);
-  }
-
-  /**
-   * Returns a one-line human-readable summary of the last path query result.
-   * Suitable for a status line or tooltip.
-   *
-   * Examples:
-   *   "EMPALME → BATAN: 9 nodes"
-   *   "EMPALME → XYZ: not found — Station not found: XYZ"
-   */
   pathQuerySummary(): string {
-    const r = this.pathQueryResult;
-    if (!r) return '';
-    if (!r.found) return `${r.from} → ${r.to}: not found — ${r.error ?? ''}`;
-    const stations = r.nodes.filter((n: PathNode) => n.kind === 'station').map((n: PathNode) => n.label);
-    return `${r.from} → ${r.to}: ${r.nodes.length} nodes (stations: ${stations.join(' → ')})`;
+    return pathQuerySummary(this.pathQueryResult());
   }
 }

--- a/metro/src/app/services/websocket.service.ts
+++ b/metro/src/app/services/websocket.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, DestroyRef, inject } from '@angular/core';
 import { BehaviorSubject, Observable, timer } from 'rxjs';
-import { retry, timeout } from 'rxjs/operators';
+import { retry, share, timeout } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { webSocket } from 'rxjs/webSocket';
 
@@ -30,7 +30,7 @@ export class WebSocketService {
     });
 
     this.messages$ = this.socket$.pipe(
-      timeout({ each: 30_000 }),
+      timeout({ each: 120_000 }),
       retry({
         count: 30,
         delay: (_error, _count) => {
@@ -39,6 +39,7 @@ export class WebSocketService {
         },
       }),
       takeUntilDestroyed(this.destroyRef),
+      share(),
     );
   }
 

--- a/metro/src/app/train/control-panel/control-panel.component.html
+++ b/metro/src/app/train/control-panel/control-panel.component.html
@@ -77,11 +77,11 @@
   <div class="section">
     <div class="section-head">
       <span class="section-title">SIMULATION</span>
-      <span class="section-meta">{{ state.paused ? 'PAUSED' : 'RUNNING' }}</span>
+      <span class="section-meta">{{ state.paused() ? 'PAUSED' : 'RUNNING' }}</span>
     </div>
     <div class="sim-controls">
-      <button class="btn-play" [class.paused]="state.paused" (click)="playPause()">
-        @if (state.paused) {
+      <button class="btn-play" [class.paused]="state.paused()" (click)="playPause()">
+        @if (state.paused()) {
           <svg viewBox="0 0 12 12" fill="currentColor"><path d="M3 2 L10 6 L3 10 Z"/></svg>
         } @else {
           <svg viewBox="0 0 12 12" fill="currentColor">
@@ -148,18 +148,18 @@
           <div class="gauge-bar" [class]="cls"></div>
         }
       </div>
-      <div class="gauge-val" [class.warn]="state.simLoad > 0.7 && state.simLoad <= 0.85"
-                             [class.crit]="state.simLoad > 0.85">
-        {{ (state.simLoad * 100).toFixed(0) }}<span class="gauge-pct">%</span>
+      <div class="gauge-val" [class.warn]="state.simLoad() > 0.7 && state.simLoad() <= 0.85"
+                             [class.crit]="state.simLoad() > 0.85">
+        {{ (state.simLoad() * 100).toFixed(0) }}<span class="gauge-pct">%</span>
       </div>
     </div>
     <div class="stat-row">
       <span class="row-name">EVENTS / TICK</span>
-      <span class="row-val">{{ state.eventsPerTick }}</span>
+      <span class="row-val">{{ state.eventsPerTick() }}</span>
     </div>
     <div class="stat-row">
       <span class="row-name">QUEUE</span>
-      <span class="row-val">{{ state.queueSize }}</span>
+      <span class="row-val">{{ state.queueSize() }}</span>
     </div>
   </div>
 

--- a/metro/src/app/train/control-panel/control-panel.component.ts
+++ b/metro/src/app/train/control-panel/control-panel.component.ts
@@ -43,7 +43,7 @@ export class ControlPanelComponent {
   ) {}
 
   gaugeCells(): string[] {
-    const filled = Math.round(this.state.simLoad * this.gaugeCount);
+    const filled = Math.round(this.state.simLoad() * this.gaugeCount);
     return Array.from({ length: this.gaugeCount }, (_, i) => {
       if (i >= filled) return '';
       if (i >= 14) return 'over';
@@ -58,10 +58,10 @@ export class ControlPanelComponent {
   }
 
   playPause(): void {
-    if (this.state.paused) {
-      this.wsService.send({ message: 'resume' });
+    if (this.state.paused()) {
+      this.wsService.resume();
     } else {
-      this.wsService.send({ message: 'pause' });
+      this.wsService.pause();
     }
   }
 

--- a/metro/src/app/train/person-tracker/person-tracker.component.html
+++ b/metro/src/app/train/person-tracker/person-tracker.component.html
@@ -8,12 +8,12 @@
   <button class="person-tracker-close" (click)="stopTracking()">✕</button>
 </div>
 <div class="person-tracker-id">
-  <span class="person-tracker-hash">#</span>{{ state.trackedPersonId!.slice(0, 8) }}
+  <span class="person-tracker-hash">#</span>{{ state.tracked()!.id!.slice(0, 8) }}
 </div>
 @if (locationLabel) {
   <div class="person-tracker-loc">
-    <span class="person-tracker-badge" [class]="'ptbadge-' + state.trackedPersonLocType">
-      {{ state.trackedPersonLocType | uppercase }}
+    <span class="person-tracker-badge" [class]="'ptbadge-' + state.tracked()?.loc?.type">
+      {{ state.tracked()?.loc?.type | uppercase }}
     </span>
     <span class="person-tracker-locname">{{ locationLabel }}</span>
   </div>

--- a/metro/src/app/train/person-tracker/person-tracker.component.ts
+++ b/metro/src/app/train/person-tracker/person-tracker.component.ts
@@ -22,8 +22,9 @@ export class PersonTrackerComponent {
   ) {}
 
   get locationLabel(): string {
-    const { trackedPersonLocType: lt, trackedPersonLocId: lid } = this.state;
-    if (!lt || !lid) return '';
+    const tracked = this.state.tracked();
+    if (!tracked?.loc) return '';
+    const { type: lt, id: lid } = tracked.loc;
     if (lt === 'station') {
       const code = NodeId.parse(lid)?.code ?? lid;
       return this.metroData.stationsByCode.get(code)?.name ?? code;
@@ -39,9 +40,11 @@ export class PersonTrackerComponent {
   }
 
   get progress(): number {
-    const { trackedPersonLocType: lt, trackedPersonLocId: lid } = this.state;
-    const nodes = this.state.trackedPersonNodes;
-    if (!nodes.length || !lt || !lid) return 0;
+    const tracked = this.state.tracked();
+    if (!tracked?.loc) return 0;
+    const nodes = tracked.nodes;
+    const { type: lt, id: lid } = tracked.loc;
+    if (!nodes.length) return 0;
     const nodeId = lt === 'station' ? lid : lt === 'platform' ? NodeId.platform(lid) : null;
     if (!nodeId) return 0;
     const idx = nodes.indexOf(nodeId);
@@ -49,7 +52,7 @@ export class PersonTrackerComponent {
   }
 
   stopTracking(): void {
-    this.state.trackedPersonId = null;
+    this.state.untrackPerson();
     this.wsService.untrackPerson();
   }
 }

--- a/metro/src/app/train/telemetry-panel/telemetry-panel.component.html
+++ b/metro/src/app/train/telemetry-panel/telemetry-panel.component.html
@@ -25,10 +25,10 @@
       <span class="section-meta">{{ peakLabel() }}</span>
     </div>
     <div class="kpi">
-      <div class="kpi-val amber">{{ formatCount(state.simulationPeople) }}<span class="unit">PAX</span></div>
+      <div class="kpi-val amber">{{ formatCount(state.simulationPeople()) }}<span class="unit">PAX</span></div>
       <div class="kpi-sub">
-        <span>IN METRO <span class="kpi-sub-v">{{ formatCount(state.metroPeople) }}</span></span>
-        <span>· EXT <span class="kpi-sub-v">{{ formatCount(state.simulationPeople - state.metroPeople) }}</span></span>
+        <span>IN METRO <span class="kpi-sub-v">{{ formatCount(state.metroPeople()) }}</span></span>
+        <span>· EXT <span class="kpi-sub-v">{{ formatCount(state.simulationPeople() - state.metroPeople()) }}</span></span>
       </div>
     </div>
     <div class="sparkline-wrap">
@@ -47,15 +47,15 @@
     </div>
     <div class="stat-row">
       <span class="row-name">IN TRAINS</span>
-      <span class="row-val" style="color:var(--cyan)">{{ formatCount(state.trainsPeople) }}</span>
+      <span class="row-val" style="color:var(--cyan)">{{ formatCount(state.trainsPeople()) }}</span>
     </div>
     <div class="stat-row">
       <span class="row-name">PLATFORMS</span>
-      <span class="row-val">{{ formatCount(allPeople(state.platformsPeople)) }}</span>
+      <span class="row-val">{{ formatCount(allPeople(state.platformsPeople())) }}</span>
     </div>
     <div class="stat-row">
       <span class="row-name">STATION HALL</span>
-      <span class="row-val">{{ formatCount(allPeople(state.stationsPeople)) }}</span>
+      <span class="row-val">{{ formatCount(allPeople(state.stationsPeople())) }}</span>
     </div>
   </div>
 

--- a/metro/src/app/train/telemetry-panel/telemetry-panel.component.ts
+++ b/metro/src/app/train/telemetry-panel/telemetry-panel.component.ts
@@ -33,17 +33,17 @@ export class TelemetryPanelComponent {
   }
 
   linePeople(): [string, number][] {
-    return Array.from(this.state.platformsPeople.entries())
+    return Array.from(this.state.platformsPeople().entries())
       .sort((a, b) => a[0].localeCompare(b[0], 'es', { numeric: true }));
   }
 
-  allPeople(recipient: Map<string, number>): number {
+  allPeople(recipient: ReadonlyMap<string, number>): number {
     const values = Array.from(recipient.values());
     return values.length === 0 ? 0 : values.reduce((p, c) => p + c);
   }
 
   linePercent(count: number): number {
-    const max = Math.max(...Array.from(this.state.platformsPeople.values()), 1);
+    const max = Math.max(...Array.from(this.state.platformsPeople().values()), 1);
     return Math.round((count / max) * 100);
   }
 

--- a/metro/src/app/train/train-panel/train-panel.component.html
+++ b/metro/src/app/train/train-panel/train-panel.component.html
@@ -7,7 +7,7 @@
   </div>
   <div class="stn-panel-row">
     <span class="k">OCUPACIÓN</span>
-    <span class="v">{{ inspectMode ? state.personsInTrain.length : t.people }} / {{ t.capacity }}</span>
+    <span class="v">{{ inspectMode ? state.personsInTrain().length : t.people }} / {{ t.capacity }}</span>
   </div>
   <div class="train-occ-bar">
     <div class="train-occ-fill"
@@ -19,10 +19,10 @@
 
   @if (inspectMode) {
     <div class="stn-panel-sep">
-      <span>PASAJEROS · {{ state.personsInTrain.length }}</span>
+      <span>PASAJEROS · {{ state.personsInTrain().length }}</span>
     </div>
     <div class="train-persons-list">
-      @for (group of groupByDest(state.personsInTrain); track group.destination) {
+      @for (group of groupByDest(state.personsInTrain()); track group.destination) {
         <button class="train-dest-btn"
                 (mousedown)="$event.stopPropagation()"
                 (click)="expandedTrainDest = expandedTrainDest === group.destination ? null : group.destination">

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -46,7 +46,7 @@
                 }
                 @if (inspectedPlatformId === p.id) {
                   <div class="platform-inspect">
-                    @let platPersons = state.personsInPlatform.get(p.id);
+                    @let platPersons = state.personsInPlatform().get(p.id);
                     @if (platPersons) {
                       @for (group of groupByDest(platPersons); track group.destination) {
                         <button class="train-dest-btn"
@@ -95,7 +95,7 @@
   }
 
   <!-- Person tracker -->
-  @if (state.trackedPersonId) {
+  @if (state.tracked()?.id) {
     <app-person-tracker />
   }
 

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { TrainComponent } from './train.component';
@@ -23,18 +23,17 @@ describe('TrainComponent', () => {
     lineDestinations: new Map<string, string>(),
   };
   const mockSimulationStateService = {
-    trains: [],
-    simulationPeople: 0,
-    metroPeople: 0,
-    trainsPeople: 0,
-    timeMultiplier: 1,
-    dirty: false,
-    paused: true,
-    platformsPeople: new Map<string, number>(),
-    stationsPeople: new Map<string, number>(),
-    andenPeople: new Map<number, number>(),
-    stationIdPeople: new Map<string, number>(),
-    trackedPersonId: null,
+    trains: signal([] as any[]),
+    simulationPeople: signal(0),
+    metroPeople: signal(0),
+    trainsPeople: signal(0),
+    timeMultiplier: signal(1),
+    paused: signal(true),
+    platformsPeople: signal(new Map<string, number>()),
+    stationsPeople: signal(new Map<string, number>()),
+    andenPeople: signal(new Map<number, number>()),
+    stationIdPeople: signal(new Map<string, number>()),
+    tracked: signal(null),
     initLines: jasmine.createSpy('initLines'),
     process: jasmine.createSpy('process'),
     getTrain: jasmine.createSpy('getTrain'),
@@ -182,12 +181,13 @@ describe('TrainComponent', () => {
 describe('TelemetryPanelComponent helpers', () => {
   let panel: TelemetryPanelComponent;
 
+  const mockPlatformsMap = new Map<string, number>();
   const mockSimulationStateService = {
-    platformsPeople: new Map<string, number>(),
-    stationsPeople: new Map<string, number>(),
-    simulationPeople: 0,
-    metroPeople: 0,
-    trainsPeople: 0,
+    platformsPeople: signal(mockPlatformsMap),
+    stationsPeople: signal(new Map<string, number>()),
+    simulationPeople: signal(0),
+    metroPeople: signal(0),
+    trainsPeople: signal(0),
   };
 
   beforeEach(async () => {
@@ -224,8 +224,9 @@ describe('TelemetryPanelComponent helpers', () => {
   // ── linePeople / allPeople ───────────────────────────────────────────────
 
   it('linePeople should return entries sorted by line name', () => {
-    mockSimulationStateService.platformsPeople.set('2', 30);
-    mockSimulationStateService.platformsPeople.set('1', 10);
+    mockPlatformsMap.set('2', 30);
+    mockPlatformsMap.set('1', 10);
+    mockSimulationStateService.platformsPeople.set(new Map(mockPlatformsMap));
     const result = panel.linePeople();
     expect(result[0][0]).toBe('1');
     expect(result[1][0]).toBe('2');
@@ -242,13 +243,12 @@ describe('TelemetryPanelComponent helpers', () => {
   // ── linePercent ──────────────────────────────────────────────────────────
 
   it('linePercent should return 100 for the maximum value', () => {
-    mockSimulationStateService.platformsPeople.clear();
-    mockSimulationStateService.platformsPeople.set('1', 50);
+    mockSimulationStateService.platformsPeople.set(new Map([['1', 50]]));
     expect(panel.linePercent(50)).toBe(100);
   });
 
   it('linePercent should return 0 when count is 0', () => {
-    mockSimulationStateService.platformsPeople.clear();
+    mockSimulationStateService.platformsPeople.set(new Map());
     expect(panel.linePercent(0)).toBe(0);
   });
 });

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -340,7 +340,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
       const dt = this.lastRafTimestamp > 0 ? timestamp - this.lastRafTimestamp : 0;
       this.lastRafTimestamp = timestamp;
-      if (!this.state.paused) {
+      if (!this.state.paused()) {
         this.time += dt * this.localSpeed;
       }
 
@@ -354,12 +354,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
       this.drawTrains(timestamp);
       this.updateStationsOverlay();
       this.updateTrainPanel();
-      this.state.dirty      = false;
       this.needsTrainRedraw = false;
 
       if (timestamp - this.lastCdTick >= 200) {
         this.lastCdTick = timestamp;
-        this.peopleHistory.push(this.state.metroPeople);
+        this.peopleHistory.push(this.state.metroPeople());
         this.peopleHistory.shift();
         this.ngZone.run(() => {});
       }
@@ -430,7 +429,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   private findNearestTrain(cx: number, cy: number, hitPx = 24): string | null {
     let best: string | null = null;
     let bestDist = hitPx * hitPx;
-    for (const t of this.state.trains) {
+    for (const t of this.state.trains()) {
       const tx = t.x * this.currentScale + this.panX;
       const ty = t.y * this.currentScale + this.panY;
       const d2 = (cx - tx) ** 2 + (cy - ty) ** 2;
@@ -523,10 +522,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   selectPerson(personId: string): void {
-    this.state.trackedPersonId = personId;
-    this.state.trackedPersonNodes = [];
-    this.state.trackedPersonLocType = '';
-    this.state.trackedPersonLocId = '';
+    this.state.trackPerson(personId);
     this.wsService.trackPerson(personId);
     this.wsService.resume();
   }
@@ -595,13 +591,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   private resolveLocToPos(): { x: number; y: number } | null {
-    const { trackedPersonLocType: lt, trackedPersonLocId: lid } = this.state;
-    if (lt === 'platform') {
-      const seg = this.metroData.paths.find(p => p.id === lid);
+    const loc = this.state.tracked()?.loc;
+    if (!loc) return null;
+    if (loc.type === 'platform') {
+      const seg = this.metroData.paths.find(p => p.id === loc.id);
       return seg ? seg.position : null;
     }
-    if (lt === 'station') {
-      const s = this.metroData.stationsByCode.get(NodeId.parse(lid)?.code ?? lid);
+    if (loc.type === 'station') {
+      const s = this.metroData.stationsByCode.get(NodeId.parse(loc.id)?.code ?? loc.id);
       return s ? s.position : null;
     }
     return null;
@@ -655,7 +652,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     const rawRatio      = TrainComponent.PATH_WIDTH_PX * 1.4 / (WAGON_H * this.currentScale);
     const trainSizeRatio = Math.max(1.0, Math.min(rawRatio, capRatio));
 
-    for (const train of this.state.trains) {
+    for (const train of this.state.trains()) {
       const wagons    = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
       const stride    = WAGON_W + WAGON_GAP;
       const halfLen   = (wagons - 1) / 2 * stride;
@@ -782,8 +779,9 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
       }
     }
 
-    if (this.state.trackedPersonId) {
-      const railPoints = this.buildPersonRailPath(this.state.trackedPersonNodes);
+    const _tracked = this.state.tracked();
+    if (_tracked?.id) {
+      const railPoints = this.buildPersonRailPath(_tracked.nodes);
       if (railPoints.length >= 2) {
         ctx.save();
         ctx.beginPath();
@@ -1023,7 +1021,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     const newSpeed = this.localSpeed;
     const now = performance.now();
     const ratio = oldSpeed / newSpeed;
-    for (const train of this.state.trains) {
+    for (const train of this.state.trains()) {
       if (train.travelMs > 0) {
         const elapsed = now - train.departedAt;
         if (elapsed < train.travelMs) {
@@ -1063,14 +1061,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     return `×${(this.currentScale / this.fitScale).toFixed(2)}`;
   }
 
-  get telemetryTrains(): number   { return this.state.trains.length; }
+  get telemetryTrains(): number   { return this.state.trains().length; }
   get telemetrySegments(): number { return this.metroData.paths.length; }
   get telemetryStations(): number { return this.metroData.stations.length; }
   get telemetryUptime(): number   { return Math.floor(this.time / 60_000) % 999; }
 
   get stationLabelItems() {
     const transitByName = new Map<string, number>();
-    this.state.stationIdPeople.forEach((count, stationId) => {
+    this.state.stationIdPeople().forEach((count, stationId) => {
       const s = this.metroData.stationsByCode.get(NodeId.parse(stationId)?.code ?? stationId);
       if (s) transitByName.set(s.name, (transitByName.get(s.name) ?? 0) + count);
     });
@@ -1082,7 +1080,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
         const line = lines[idx] ?? '';
         const destination = this.metroData.lineDestinations.get(`${line}/${pe.sentido}`) ?? '';
         return { id: pe.id, line, sentido: pe.sentido, destination,
-                 total: this.state.andenPeople.get(parseInt(pe.id, 10)) ?? 0 };
+                 total: this.state.andenPeople().get(parseInt(pe.id, 10)) ?? 0 };
       });
       const destCount = new Map<string, number>();
       platforms.forEach(p => destCount.set(p.destination, (destCount.get(p.destination) ?? 0) + 1));

--- a/metro/src/app/utils/path-summary.ts
+++ b/metro/src/app/utils/path-summary.ts
@@ -1,0 +1,10 @@
+import { PathNode, PathResult } from '../messages';
+
+export function pathQuerySummary(result: PathResult | null): string {
+  if (!result) return '';
+  if (!result.found) return `${result.from} → ${result.to}: not found — ${result.error ?? ''}`;
+  const stations = result.nodes
+    .filter((n: PathNode) => n.kind === 'station')
+    .map((n: PathNode) => n.label);
+  return `${result.from} → ${result.to}: ${result.nodes.length} nodes (stations: ${stations.join(' → ')})`;
+}


### PR DESCRIPTION
Closes #93, #94. Parte del plan #88 (Fase 2).

## Summary

- **SimulationStateService** (issue #93): todas las props mutables convertidas a `signal()`. Maps de personas expuestos como `signal<ReadonlyMap<...>>`. Las 4 props de tracking (`trackedPersonId/Nodes/LocType/LocId`) agrupadas en un único `tracked = signal<TrackedPerson | null>`. Flag `dirty` eliminado. Método `queryPath()` eliminado (ya existe en `WebSocketService`). `pathQuerySummary` extraída a `utils/path-summary.ts`.
- **WebSocketService** (issue #94): `share()` añadido a `messages$` para garantizar una sola conexión WS con múltiples suscriptores. Timeout subido de 30 s a 120 s para evitar reconexiones espurias con la simulación pausada. `ControlPanelComponent` migrado a los métodos tipados `pause()`/`resume()`.

## Test plan

- [ ] `npm run build` sin errores de tipo
- [ ] `npm test` 106/106 verdes
- [ ] Verificar en el browser que la simulación arranca, los trenes se mueven y los paneles muestran datos correctamente