### PR TITLE
[Refactor F4] Template breakdown + computed stationLabelItems + Angular overlay bindings

### DIFF
--- a/metro/src/app/train/bottom-telemetry/bottom-telemetry.component.ts
+++ b/metro/src/app/train/bottom-telemetry/bottom-telemetry.component.ts
@@ -1,0 +1,23 @@
+import { Component, ChangeDetectionStrategy, input } from '@angular/core';
+
+@Component({
+  selector: 'app-bottom-telemetry',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="telemetry" [style.--p]="(progress() * 100).toFixed(1) + '%'">
+      <span class="telemetry-tag">▸ NET</span>
+      <div class="telemetry-track"></div>
+      <div class="telemetry-stat"><span class="k">TRAINS</span><span class="v">{{ trains() }}</span></div>
+      <div class="telemetry-stat"><span class="k">SEGMENTS</span><span class="v">{{ segments() }}</span></div>
+      <div class="telemetry-stat"><span class="k">STATIONS</span><span class="v">{{ stations() }}</span></div>
+      <div class="telemetry-stat"><span class="k">UPTIME</span><span class="v">{{ uptime() }}m</span></div>
+    </div>
+  `,
+})
+export class BottomTelemetryComponent {
+  trains   = input.required<number>();
+  segments = input.required<number>();
+  stations = input.required<number>();
+  uptime   = input.required<number>();
+  progress = input.required<number>();
+}

--- a/metro/src/app/train/platform-inspect/platform-inspect.component.ts
+++ b/metro/src/app/train/platform-inspect/platform-inspect.component.ts
@@ -1,0 +1,62 @@
+import { Component, ChangeDetectionStrategy, input, output, signal } from '@angular/core';
+
+import { PersonEntry } from '../../messages';
+
+@Component({
+  selector: 'app-platform-inspect',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="platform-inspect">
+      @if (persons(); as ps) {
+        @for (group of groupByDest(ps); track group.destination) {
+          <button class="train-dest-btn"
+                  (mousedown)="$event.stopPropagation()"
+                  (click)="toggleDest(group.destination)">
+            <span class="train-dest-label">→ {{ group.destination || '?' }}</span>
+            <span class="train-dest-count">{{ group.ids.length }}</span>
+            <span class="train-dest-arrow">{{ expandedDest() === group.destination ? '▴' : '▾' }}</span>
+          </button>
+          @if (expandedDest() === group.destination) {
+            @for (pid of group.ids; track pid) {
+              <button class="train-person-btn"
+                      (mousedown)="$event.stopPropagation()"
+                      (click)="personSelect.emit(pid)">
+                {{ pid.slice(0, 8) }}
+              </button>
+            }
+          }
+        }
+        <button class="train-inspect-btn"
+                (mousedown)="$event.stopPropagation()"
+                (click)="closeInspect.emit()">
+          CERRAR
+        </button>
+      } @else {
+        <div class="platform-inspect-loading">cargando…</div>
+      }
+    </div>
+  `,
+})
+export class PlatformInspectComponent {
+  persons = input.required<PersonEntry[] | undefined>();
+
+  closeInspect = output<void>();
+  personSelect = output<string>();
+
+  readonly expandedDest = signal<string | null>(null);
+
+  toggleDest(dest: string): void {
+    this.expandedDest.update(d => d === dest ? null : dest);
+  }
+
+  groupByDest(persons: PersonEntry[]): Array<{ destination: string; ids: string[] }> {
+    const map = new Map<string, string[]>();
+    for (const p of persons) {
+      if (!map.has(p.destination)) map.set(p.destination, []);
+      map.get(p.destination)!.push(p.id);
+    }
+    return Array.from(map.entries())
+      .map(([destination, ids]) => ({ destination, ids }))
+      .sort((a, b) => b.ids.length - a.ids.length);
+  }
+}

--- a/metro/src/app/train/station-card/station-card.component.ts
+++ b/metro/src/app/train/station-card/station-card.component.ts
@@ -1,0 +1,69 @@
+import { Component, ChangeDetectionStrategy, input, output } from '@angular/core';
+
+import { PersonEntry } from '../../messages';
+import { StationLabelItem } from '../station-label-item';
+import { PlatformInspectComponent } from '../platform-inspect/platform-inspect.component';
+import { lineColor, fmtCount } from '../../utils/format';
+
+@Component({
+  selector: 'app-station-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [PlatformInspectComponent],
+  template: `
+    <div class="stn-label">
+      <div class="stn-name"
+           (mousedown)="$event.stopPropagation()"
+           (click)="labelClick.emit()">
+        <span class="stn-tick"></span>
+        <span class="stn-text">{{ item().name }}</span>
+      </div>
+      <div class="stn-panel">
+        <div class="stn-panel-row stn-total">
+          <span class="k">TOTAL</span>
+          <span class="v">{{ fmt(item().total) }}</span>
+        </div>
+        <div class="stn-panel-row stn-transit">
+          <span class="k">↳ TRANSIT</span>
+          <span class="v">{{ fmt(item().transit) }}</span>
+        </div>
+        <div class="stn-panel-sep">
+          <span>{{ item().lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item().lines.length }}</span>
+        </div>
+        @for (p of item().platforms; track p.id) {
+          <div class="stn-platform">
+            <span class="line-chip"
+                  [style.background]="lineColor(p.line)"
+                  [style.color]="p.line === 'R' ? '#000' : '#fff'">{{ p.line }}</span>
+            <span class="stn-direction">→ {{ p.destination }}</span>
+            <span class="stn-platform-count">{{ fmt(p.total) }}</span>
+          </div>
+          @if (inspectedPlatformId() !== p.id) {
+            <button class="train-inspect-btn"
+                    (mousedown)="$event.stopPropagation()"
+                    (click)="platformInspect.emit(p.id)">
+              INSPECCIONAR
+            </button>
+          }
+          @if (inspectedPlatformId() === p.id) {
+            <app-platform-inspect
+              [persons]="personsInPlatform()?.get(p.id)"
+              (closeInspect)="platformInspect.emit(p.id)"
+              (personSelect)="personSelect.emit($event)" />
+          }
+        }
+      </div>
+    </div>
+  `,
+})
+export class StationCardComponent {
+  item               = input.required<StationLabelItem>();
+  inspectedPlatformId = input<string | null>(null);
+  personsInPlatform  = input<ReadonlyMap<string, PersonEntry[]> | null>(null);
+
+  labelClick     = output<void>();
+  platformInspect = output<string>();
+  personSelect   = output<string>();
+
+  lineColor = lineColor;
+  fmt       = fmtCount;
+}

--- a/metro/src/app/train/station-label-item.ts
+++ b/metro/src/app/train/station-label-item.ts
@@ -1,0 +1,17 @@
+export interface PlatformItem {
+  id: string;
+  line: string;
+  sentido: string;
+  destination: string;
+  total: number;
+}
+
+export interface StationLabelItem {
+  name: string;
+  x: number;
+  y: number;
+  lines: string[];
+  platforms: PlatformItem[];
+  total: number;
+  transit: number;
+}

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -1,6 +1,6 @@
 <div class="map-root">
 
-  <!-- Canvas layers -->
+  <!-- Canvas layers + interaction directive -->
   <div class="canvas-container" #canvasContainer appMapInteraction
     (mapZoom)="onMapZoom($event)"
     (mapPan)="onMapPan($event)"
@@ -12,78 +12,22 @@
     <canvas #canvas_stations class="canvas-layer"></canvas>
     <canvas #canvas_trains   class="canvas-layer"></canvas>
 
-    <!-- Station labels overlay (HTML, positioned via RAF) -->
-    <div #stationsOverlay class="station-labels">
-      @for (item of stationLabelItems; track item.name; let idx = $index) {
-        <div class="stn-label-wrap" [class.is-interchange]="item.lines.length >= 2">
-          <div class="stn-label">
-            <div class="stn-name"
-                 (mousedown)="$event.stopPropagation()"
-                 (click)="onStationLabelClick(idx)">
-              <span class="stn-tick"></span>
-              <span class="stn-text">{{ item.name }}</span>
-            </div>
-            <div class="stn-panel">
-              <div class="stn-panel-row stn-total">
-                <span class="k">TOTAL</span>
-                <span class="v">{{ fmtCount(item.total) }}</span>
-              </div>
-              <div class="stn-panel-row stn-transit">
-                <span class="k">↳ TRANSIT</span>
-                <span class="v">{{ fmtCount(item.transit) }}</span>
-              </div>
-              <div class="stn-panel-sep">
-                <span>{{ item.lines.length === 1 ? 'PLATFORM' : 'PLATFORMS · ' + item.lines.length }}</span>
-              </div>
-              @for (p of item.platforms; track p.id) {
-                <div class="stn-platform">
-                  <span class="line-chip" [style.background]="lineColors(p.line)"
-                        [style.color]="p.line === 'R' ? '#000' : '#fff'">{{ p.line }}</span>
-                  <span class="stn-direction">→ {{ p.destination }}</span>
-                  <span class="stn-platform-count">{{ fmtCount(p.total) }}</span>
-                </div>
-                @if (inspectedPlatformId !== p.id) {
-                  <button class="train-inspect-btn"
-                          (mousedown)="$event.stopPropagation()"
-                          (click)="togglePlatformInspect(p.id)">
-                    INSPECCIONAR
-                  </button>
-                }
-                @if (inspectedPlatformId === p.id) {
-                  <div class="platform-inspect">
-                    @let platPersons = state.personsInPlatform().get(p.id);
-                    @if (platPersons) {
-                      @for (group of groupByDest(platPersons); track group.destination) {
-                        <button class="train-dest-btn"
-                                (mousedown)="$event.stopPropagation()"
-                                (click)="expandedPlatformDest = expandedPlatformDest === group.destination ? null : group.destination">
-                          <span class="train-dest-label">→ {{ group.destination || '?' }}</span>
-                          <span class="train-dest-count">{{ group.ids.length }}</span>
-                          <span class="train-dest-arrow">{{ expandedPlatformDest === group.destination ? '▴' : '▾' }}</span>
-                        </button>
-                        @if (expandedPlatformDest === group.destination) {
-                          @for (pid of group.ids; track pid) {
-                            <button class="train-person-btn"
-                                    (mousedown)="$event.stopPropagation()"
-                                    (click)="selectPerson(pid)">
-                              {{ pid.slice(0, 8) }}
-                            </button>
-                          }
-                        }
-                      }
-                      <button class="train-inspect-btn"
-                              (mousedown)="$event.stopPropagation()"
-                              (click)="togglePlatformInspect(p.id)">
-                        CERRAR
-                      </button>
-                    } @else {
-                      <div class="platform-inspect-loading">cargando…</div>
-                    }
-                  </div>
-                }
-              }
-            </div>
-          </div>
+    <!-- Station labels overlay — positioned via Angular bindings (#103) -->
+    <div class="station-labels" [ngClass]="overlayClasses()">
+      @for (item of stationLabelItems(); track item.name; let idx = $index) {
+        <div class="stn-label-wrap"
+             [class.is-interchange]="item.lines.length >= 2"
+             [class.is-selected]="selectedStationIdx() === idx"
+             [class.is-hover]="hoveredStationIdx() === idx"
+             [style.left.px]="item.x * viewport.scale() + viewport.panX()"
+             [style.top.px]="item.y * viewport.scale() + viewport.panY()">
+          <app-station-card
+            [item]="item"
+            [inspectedPlatformId]="inspectedPlatformId()"
+            [personsInPlatform]="state.personsInPlatform()"
+            (labelClick)="onStationLabelClick(idx)"
+            (platformInspect)="togglePlatformInspect($event)"
+            (personSelect)="selectPerson($event)" />
         </div>
       }
     </div>
@@ -106,10 +50,8 @@
 
   <!-- Corner brackets -->
   <div class="corners" aria-hidden="true">
-    <div class="corner tl"></div>
-    <div class="corner tr"></div>
-    <div class="corner bl"></div>
-    <div class="corner br"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
   </div>
 
   <!-- Scope crosshair -->
@@ -137,17 +79,15 @@
   <app-telemetry-panel
     [peakLabel]="peakLabel"
     [peopleHistory]="peopleHistory"
-    [showAllPanels]="showAllPanels"
+    [showAllPanels]="showAllPanels()"
     (toggleShowAllPanels)="toggleShowAllPanels()" />
 
-  <!-- Bottom telemetry strip -->
-  <div class="telemetry" [style.--p]="((dayProgress) * 100).toFixed(1) + '%'">
-    <span class="telemetry-tag">▸ NET</span>
-    <div class="telemetry-track"></div>
-    <div class="telemetry-stat"><span class="k">TRAINS</span><span class="v">{{ telemetryTrains }}</span></div>
-    <div class="telemetry-stat"><span class="k">SEGMENTS</span><span class="v">{{ telemetrySegments }}</span></div>
-    <div class="telemetry-stat"><span class="k">STATIONS</span><span class="v">{{ telemetryStations }}</span></div>
-    <div class="telemetry-stat"><span class="k">UPTIME</span><span class="v">{{ telemetryUptime }}m</span></div>
-  </div>
+  <!-- Bottom telemetry strip (#101) -->
+  <app-bottom-telemetry
+    [trains]="telemetryTrains"
+    [segments]="telemetrySegments"
+    [stations]="telemetryStations"
+    [uptime]="telemetryUptime"
+    [progress]="dayProgress" />
 
 </div>

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -158,23 +158,23 @@ describe('TrainComponent', () => {
 
   it('toggleShowAllPanels first click should set showAllPanels to true', () => {
     component.toggleShowAllPanels();
-    expect(component.showAllPanels).toBeTrue();
-    expect((component as any).stationsHidden).toBeFalse();
+    expect(component.showAllPanels()).toBeTrue();
+    expect(component.stationsHidden()).toBeFalse();
   });
 
   it('toggleShowAllPanels second click should hide all and set stationsHidden', () => {
     component.toggleShowAllPanels();
     component.toggleShowAllPanels();
-    expect(component.showAllPanels).toBeFalse();
-    expect((component as any).stationsHidden).toBeTrue();
+    expect(component.showAllPanels()).toBeFalse();
+    expect(component.stationsHidden()).toBeTrue();
   });
 
   it('toggleShowAllPanels third click should show all again', () => {
     component.toggleShowAllPanels();
     component.toggleShowAllPanels();
     component.toggleShowAllPanels();
-    expect(component.showAllPanels).toBeTrue();
-    expect((component as any).stationsHidden).toBeFalse();
+    expect(component.showAllPanels()).toBeTrue();
+    expect(component.stationsHidden()).toBeFalse();
   });
 });
 

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -1,4 +1,5 @@
-import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy, OnInit, NgZone, ChangeDetectorRef, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild, ElementRef, AfterViewInit, OnDestroy, OnInit, NgZone, ChangeDetectorRef, ChangeDetectionStrategy, signal, computed } from '@angular/core';
+import { NgClass } from '@angular/common';
 import { environment } from '../../environments/environment';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -22,11 +23,14 @@ import { TrainPanelComponent } from './train-panel/train-panel.component';
 import { TelemetryPanelComponent } from './telemetry-panel/telemetry-panel.component';
 import { ControlPanelComponent } from './control-panel/control-panel.component';
 import { MapInteractionDirective } from './map-interaction.directive';
+import { StationCardComponent } from './station-card/station-card.component';
+import { BottomTelemetryComponent } from './bottom-telemetry/bottom-telemetry.component';
+import { StationLabelItem } from './station-label-item';
 
 @Component({
   selector: 'app-train',
   standalone: true,
-  imports: [PersonTrackerComponent, TrainPanelComponent, TelemetryPanelComponent, ControlPanelComponent, MapInteractionDirective],
+  imports: [NgClass, PersonTrackerComponent, TrainPanelComponent, TelemetryPanelComponent, ControlPanelComponent, MapInteractionDirective, StationCardComponent, BottomTelemetryComponent],
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -39,16 +43,27 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   @ViewChild('canvas_stations', { static: false, read: ElementRef }) canvasStations!: ElementRef;
   @ViewChild('canvas_paths',    { static: false, read: ElementRef }) canvasPaths!: ElementRef;
   @ViewChild('canvas_trains',   { static: false, read: ElementRef }) canvasTrains!: ElementRef;
-  @ViewChild('stationsOverlay', { static: false, read: ElementRef }) private stationsOverlay!: ElementRef;
-  private _overlayElements: HTMLElement[] | null = null;
-  private selectedStationIdx  = -1;
-  private _lastSelectedIdx    = -2;
-  private _hoveredStationIdx  = -1;
-  private _lastHoveredIdx     = -2;
-  private _mouseContainerX    = -1;
-  private _mouseContainerY    = -1;
-  showAllPanels = false;
-  private stationsHidden = false;
+
+  private _mouseContainerX = -1;
+  private _mouseContainerY = -1;
+
+  readonly showAllPanels   = signal(false);
+  readonly stationsHidden  = signal(false);
+  readonly selectedStationIdx = signal(-1);
+  readonly hoveredStationIdx  = signal(-1);
+
+  // Computed overlay container classes (#103)
+  readonly overlayClasses = computed(() => {
+    const fitMul = this.viewport.scale() / this.viewport.fitScale();
+    const show   = this.showAllPanels();
+    const hide   = this.stationsHidden();
+    return {
+      'show-interchange': !hide && (fitMul > 1.05 || show),
+      'show-all':         !hide && (fitMul > 1.7  || show),
+      'show-panel':       !hide && (fitMul > 15   || show),
+      'zoom-deep':        fitMul > 7,
+    };
+  });
 
   private ctxTiles!: CanvasRenderingContext2D;
   private ctxStations!: CanvasRenderingContext2D;
@@ -76,15 +91,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   resetTime = '06:05';
 
-  private stationLineMap = new Map<string, string[]>();
-  private stationPlatformIds = new Map<string, { id: string; sentido: string }[]>();
+  // Static part precomputed once in buildStationLineMap (#102)
+  private staticStations: Array<{
+    name: string; x: number; y: number; lines: string[];
+    platforms: Array<{ id: string; line: string; sentido: string; destination: string }>;
+  }> = [];
 
   selectedTrainId: string | null = null;
   hoveredTrainId: string | null = null;
   trainPanelX = 0;
   trainPanelY = 0;
-  inspectedPlatformId: string | null = null;
-  expandedPlatformDest: string | null = null;
+  readonly inspectedPlatformId = signal<string | null>(null);
 
   readonly peopleHistory: number[] = Array(40).fill(0);
 
@@ -226,11 +243,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   onMapMove(e: { x: number; y: number }): void {
     this._mouseContainerX = e.x;
     this._mouseContainerY = e.y;
+    this.hoveredStationIdx.set(this.findNearestStation(e.x, e.y, 14));
     const container = this.canvasContainer.nativeElement as HTMLElement;
     const nearTrain = this.findNearestTrain(e.x, e.y, 40);
     if (nearTrain) { container.style.cursor = 'pointer'; return; }
-    const near = this.findNearestStation(e.x, e.y, 14);
-    container.style.cursor = near >= 0 ? 'pointer' : 'grab';
+    container.style.cursor = this.hoveredStationIdx() >= 0 ? 'pointer' : 'grab';
   }
 
   onMapClick(e: { x: number; y: number }): void {
@@ -281,7 +298,6 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
       }
 
       this.drawTrains(timestamp);
-      this.updateStationsOverlay();
       this.updateTrainPanel();
       this.needsTrainRedraw = false;
 
@@ -365,75 +381,25 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   get selectedTrain() { return this.selectedTrainId ? this.state.getTrain(this.selectedTrainId) : undefined; }
 
-  private handleMapClick(clientX: number, clientY: number): void {
-    const rect = (this.canvasContainer.nativeElement as HTMLElement).getBoundingClientRect();
-    const mx = clientX - rect.left;
-    const my = clientY - rect.top;
-
-    const nearTrain = this.findNearestTrain(mx, my, 40);
+  private handleMapClick(x: number, y: number): void {
+    const nearTrain = this.findNearestTrain(x, y, 40);
     if (nearTrain) {
       this.selectedTrainId = nearTrain === this.selectedTrainId ? null : nearTrain;
-      this.selectedStationIdx = -1;
+      this.selectedStationIdx.set(-1);
       return;
     }
-
-    const bestIdx = this.findNearestStation(mx, my);
-    this.selectedStationIdx = bestIdx === this.selectedStationIdx ? -1 : bestIdx;
+    const bestIdx = this.findNearestStation(x, y);
+    this.selectedStationIdx.update(cur => bestIdx === cur ? -1 : bestIdx);
     this.selectedTrainId = null;
   }
 
   toggleShowAllPanels(): void {
-    if (!this.showAllPanels) {
-      this.showAllPanels   = true;
-      this.stationsHidden  = false;
+    if (!this.showAllPanels()) {
+      this.showAllPanels.set(true);
+      this.stationsHidden.set(false);
     } else {
-      this.showAllPanels   = false;
-      this.stationsHidden  = true;
-    }
-    this.applyOverlayClasses();
-  }
-
-  private applyOverlayClasses(): void {
-    const el = this.stationsOverlay?.nativeElement as HTMLElement | undefined;
-    if (!el) return;
-    const fitMul    = this.viewport.scale() / this.viewport.fitScale();
-    const forceShow = this.showAllPanels;
-    const forceHide = this.stationsHidden;
-    el.classList.toggle('show-interchange', !forceHide && (fitMul > 1.05 || forceShow));
-    el.classList.toggle('show-all',         !forceHide && (fitMul > 1.7  || forceShow));
-    el.classList.toggle('show-panel',       !forceHide && (fitMul > 15   || forceShow));
-    el.classList.toggle('zoom-deep',        fitMul > 7);
-  }
-
-  private updateStationsOverlay(): void {
-    this.applyOverlayClasses();
-    const el = this.stationsOverlay?.nativeElement as HTMLElement | undefined;
-    if (!el) return;
-    if (!this._overlayElements) {
-      const items = el.querySelectorAll<HTMLElement>('.stn-label-wrap');
-      if (items.length > 0) this._overlayElements = Array.from(items);
-    }
-    if (this._overlayElements) {
-      const stations = this.metroData.stations;
-      const s = this.viewport.scale(), px = this.viewport.panX(), py = this.viewport.panY();
-      for (let i = 0; i < this._overlayElements.length; i++) {
-        const st = stations[i];
-        if (!st) continue;
-        this._overlayElements[i].style.left = (st.position.x * s + px) + 'px';
-        this._overlayElements[i].style.top  = (st.position.y * s + py) + 'px';
-      }
-      if (this.selectedStationIdx !== this._lastSelectedIdx) {
-        if (this._lastSelectedIdx >= 0) this._overlayElements[this._lastSelectedIdx]?.classList.remove('is-selected');
-        if (this.selectedStationIdx >= 0) this._overlayElements[this.selectedStationIdx]?.classList.add('is-selected');
-        this._lastSelectedIdx = this.selectedStationIdx;
-      }
-      const hoverIdx = this.findNearestStation(this._mouseContainerX, this._mouseContainerY, 14);
-      if (hoverIdx !== this._lastHoveredIdx) {
-        if (this._lastHoveredIdx >= 0) this._overlayElements[this._lastHoveredIdx]?.classList.remove('is-hover');
-        if (hoverIdx >= 0) this._overlayElements[hoverIdx]?.classList.add('is-hover');
-        this._hoveredStationIdx = hoverIdx;
-        this._lastHoveredIdx = hoverIdx;
-      }
+      this.showAllPanels.set(false);
+      this.stationsHidden.set(true);
     }
   }
 
@@ -453,42 +419,56 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   togglePlatformInspect(anderId: string): void {
-    if (this.inspectedPlatformId === anderId) {
-      this.inspectedPlatformId = null;
-      this.expandedPlatformDest = null;
+    if (this.inspectedPlatformId() === anderId) {
+      this.inspectedPlatformId.set(null);
       this.wsService.resume();
       return;
     }
-    this.inspectedPlatformId = anderId;
-    this.expandedPlatformDest = null;
+    this.inspectedPlatformId.set(anderId);
     this.wsService.pause();
     this.wsService.requestPlatformPersons(anderId);
   }
 
   onStationLabelClick(idx: number): void {
-    this.selectedStationIdx = idx === this.selectedStationIdx ? -1 : idx;
+    this.selectedStationIdx.update(cur => cur === idx ? -1 : idx);
   }
 
   // Build a polyline following actual rail geometry for the person's planned path.
-  // The first platform node's tramo goes FROM the origin station TO the next station —
 
   private buildStationLineMap(): void {
-    this.stationLineMap.clear();
-    this.stationPlatformIds.clear();
+    const lineMap   = new Map<string, string[]>();
+    const platformMap = new Map<string, { id: string; sentido: string }[]>();
     const seen = new Map<string, Set<string>>();
     for (const p of this.metroData.paths) {
       const dirKey = p.line + '/' + p.sentido;
       if (!seen.has(p.name)) seen.set(p.name, new Set());
       if (!seen.get(p.name)!.has(dirKey)) {
         seen.get(p.name)!.add(dirKey);
-        const lines = this.stationLineMap.get(p.name) ?? [];
+        const lines = lineMap.get(p.name) ?? [];
         lines.push(p.line);
-        this.stationLineMap.set(p.name, lines);
-        const pids = this.stationPlatformIds.get(p.name) ?? [];
+        lineMap.set(p.name, lines);
+        const pids = platformMap.get(p.name) ?? [];
         pids.push({ id: p.id, sentido: p.sentido });
-        this.stationPlatformIds.set(p.name, pids);
+        platformMap.set(p.name, pids);
       }
     }
+    // Precompute static station data (#102)
+    this.staticStations = this.metroData.stations.map(s => {
+      const lines    = lineMap.get(s.name) ?? [];
+      const pEntries = platformMap.get(s.name) ?? [];
+      const platforms = pEntries.map((pe, idx) => {
+        const line = lines[idx] ?? '';
+        const dest = this.metroData.lineDestinations.get(`${line}/${pe.sentido}`) ?? '';
+        return { id: pe.id, line, sentido: pe.sentido, destination: dest };
+      });
+      // disambiguate duplicate destinations
+      const destCount = new Map<string, number>();
+      platforms.forEach(p => destCount.set(p.destination, (destCount.get(p.destination) ?? 0) + 1));
+      platforms.forEach(p => {
+        if (p.destination && (destCount.get(p.destination) ?? 0) > 1) p.destination += ` ·${p.sentido}`;
+      });
+      return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms };
+    });
   }
 
   private drawStations(): void { this.renderer.drawStations(this.ctxStations); }
@@ -560,33 +540,25 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   get telemetryStations(): number { return this.metroData.stations.length; }
   get telemetryUptime(): number   { return this.clock.uptime(); }
 
-  get stationLabelItems() {
-    const transitByName = new Map<string, number>();
-    this.state.stationIdPeople().forEach((count, stationId) => {
+  // Reactive computed — only reruns when stationIdPeople or andenPeople signals change (#102)
+  readonly stationLabelItems = computed((): StationLabelItem[] => {
+    const stationIdPeople = this.state.stationIdPeople();
+    const andenPeople     = this.state.andenPeople();
+    const transitByName   = new Map<string, number>();
+    stationIdPeople.forEach((count, stationId) => {
       const s = this.metroData.stationsByCode.get(NodeId.parse(stationId)?.code ?? stationId);
       if (s) transitByName.set(s.name, (transitByName.get(s.name) ?? 0) + count);
     });
-
-    return this.metroData.stations.map(s => {
-      const lines       = this.stationLineMap.get(s.name) ?? [];
-      const platformEntries = this.stationPlatformIds.get(s.name) ?? [];
-      const platforms   = platformEntries.map((pe, idx) => {
-        const line = lines[idx] ?? '';
-        const destination = this.metroData.lineDestinations.get(`${line}/${pe.sentido}`) ?? '';
-        return { id: pe.id, line, sentido: pe.sentido, destination,
-                 total: this.state.andenPeople().get(parseInt(pe.id, 10)) ?? 0 };
-      });
-      const destCount = new Map<string, number>();
-      platforms.forEach(p => destCount.set(p.destination, (destCount.get(p.destination) ?? 0) + 1));
-      platforms.forEach(p => {
-        if (p.destination && (destCount.get(p.destination) ?? 0) > 1)
-          p.destination += ` ·${p.sentido}`;
-      });
+    return this.staticStations.map(s => {
+      const platforms = s.platforms.map(p => ({
+        ...p,
+        total: andenPeople.get(parseInt(p.id, 10)) ?? 0,
+      }));
       const transit = transitByName.get(s.name) ?? 0;
       const total   = transit + platforms.reduce((sum, p) => sum + p.total, 0);
-      return { name: s.name, x: s.position.x, y: s.position.y, lines, platforms, total, transit };
+      return { ...s, platforms, total, transit };
     });
-  }
+  });
 
   get peakLabel(): string { return this.clock.peakLabel(); }
 }


### PR DESCRIPTION
Closes #101, #102, #103. Parte del plan #88 (Fase 4).

## Summary

- **#101 Romper template**: `train.component.html` pasa de 153 → 93 líneas. Nuevos componentes:
  - `StationCardComponent` — card de una estación (línea, destino, totales, INSPECCIONAR)
  - `PlatformInspectComponent` — popup de inspección de andén con groupByDest local y expanded dest por tarjeta
  - `BottomTelemetryComponent` — franja inferior de telemetría

- **#102 `stationLabelItems` como `computed()`**: La parte estática (líneas, destinos, sentidos) se precomputa una sola vez en `buildStationLineMap`. El `computed()` solo recalcula totales cuando `stationIdPeople` o `andenPeople` cambian — elimina reconstrucción en cada tick de CD.

- **#103 Eliminar DOM imperativo**: `_overlayElements`, `classList.toggle`, `style.left/top` directos eliminados. Reemplazados por:
  - `[style.left.px]` / `[style.top.px]` bound a signals de viewport
  - `[class.is-selected]` / `[class.is-hover]` bound a signals `selectedStationIdx` / `hoveredStationIdx`
  - `[ngClass]="overlayClasses()"` computed que depende de `viewport.scale()` y signals de showAllPanels/stationsHidden
  - `hoveredStationIdx` se actualiza en `onMapMove` (dentro de zone) en lugar del RAF loop

## Test plan

- [ ] `npm run build` sin errores de tipo
- [ ] `npm test` 130/130 verdes
- [ ] Verificar en browser: overlay de estaciones se posiciona correctamente, hover/selected funcionan, inspección de andén, bottom strip visible