### PR TITLE
[Refactor F6+F7] Tests, Segment/TrainView domain split, magic constants

### DIFF
--- a/metro/src/app/constants.ts
+++ b/metro/src/app/constants.ts
@@ -18,6 +18,16 @@ export const WAGON_W    = 1.15;
 export const WAGON_H    = 0.70;
 export const WAGON_GAP  = 0.12;
 
+// Hit-test radii (screen pixels)
+export const TRAIN_HIT_PX   = 40;
+export const STATION_HIT_PX = 14;
+
+// Render loop and change-detection intervals (ms)
+export const CD_TICK_MS = 200;
+
+// Path-geometry: squared distance threshold to consider two tramo endpoints connected
+export const CONNECT_SQ = 4;
+
 // Colors per metro line (key = line identifier used in simulation messages)
 export const LINE_COLORS: Record<string, string> = {
   '1': '#0097C9',

--- a/metro/src/app/domain/segment.ts
+++ b/metro/src/app/domain/segment.ts
@@ -1,0 +1,10 @@
+export interface Segment {
+  id: string;
+  name: string;
+  line: string;
+  sentido: string;
+  path: { x: number; y: number }[];
+  position: { x: number; y: number };
+  longitudM: number;
+  velocidadKmh: number;
+}

--- a/metro/src/app/madrid.ts
+++ b/metro/src/app/madrid.ts
@@ -1,55 +1,53 @@
-import {Position} from './position'
-import {Slot} from './slot'
-import {Station} from './station'
-import rawStations from '../assets/stations.json'
-import rawPaths from '../assets/tramos.json'
+import { lonLatToCanvas } from './utils/projection';
+import { Segment } from './domain/segment';
+import rawStations from '../assets/stations.json';
+import rawPaths from '../assets/tramos.json';
+
+export interface StationInfo {
+  name: string;
+  position: { x: number; y: number };
+}
 
 export class Madrid {
-  width: number;
-  height: number;
-  stations: Station[];
-  paths: Station[];
-  stationsByCode: Map<string, Station> = new Map();
+  readonly stations: StationInfo[];
+  readonly segments: Segment[];
+  readonly stationsByCode: Map<string, StationInfo> = new Map();
 
+  constructor(_width: number, _height: number) {
+    // Build segments from tramos.json
+    this.segments = rawPaths.features.map(f => {
+      const path = f.geometry.coordinates.map(c => lonLatToCanvas(c[0], c[1]));
+      const last = f.geometry.coordinates[f.geometry.coordinates.length - 1];
+      const position = lonLatToCanvas(last[0], last[1]);
+      return {
+        id:           f.properties.CODIGOANDEN.toString(),
+        name:         f.properties.DENOMINACION,
+        line:         f.properties.NUMEROLINEAUSUARIO,
+        sentido:      f.properties.SENTIDO,
+        path,
+        position,
+        longitudM:    f.properties.LONGITUDTRAMOANTERIOR ?? 0,
+        velocidadKmh: f.properties.VELOCIDADTRAMOANTERIOR ?? 0,
+      } satisfies Segment;
+    });
 
-  constructor(width: number, height: number) {
-    this.width = width;
-    this.height = height;
+    // Build deduplicated stations from stations.json
+    const seen = new Set<string>();
     this.stations = [];
-    this.paths = [];
-
-    // Build paths
-    for (let p of rawPaths.features) {
-      const path: Position[] = []
-      for (let c of p.geometry.coordinates) {
-        const position = new Position(width, height, c[1], c[0]);
-        path.push(position)
-      }
-      const position = new Position(width, height, p.geometry.coordinates.reverse()[0][1],
-        p.geometry.coordinates.reverse()[0][0]);
-      const slots: Slot[] = []
-      const station = new Station(p.properties.CODIGOANDEN.toString(), p.properties.DENOMINACION,
-        p.properties.NUMEROLINEAUSUARIO, position, path, p.properties.SENTIDO, slots,
-        undefined,
-        p.properties.LONGITUDTRAMOANTERIOR ?? 0,
-        p.properties.VELOCIDADTRAMOANTERIOR ?? 0)
-      this.paths.push(station)
-    }
-
-    // Build stations (deduplicated by name)
-    for (let s of rawStations.features) {
-      if (this.stations.filter(x => x.name === s.properties.DENOMINACION).length == 0) {
-        const position = new Position(width, height, s.geometry.coordinates[1], s.geometry.coordinates[0]);
-        const station = new Station("", s.properties.DENOMINACION, "", position, [], "", [])
-        this.stations.push(station)
+    for (const s of rawStations.features) {
+      const name = s.properties.DENOMINACION;
+      if (!seen.has(name)) {
+        seen.add(name);
+        this.stations.push({ name, position: lonLatToCanvas(s.geometry.coordinates[0], s.geometry.coordinates[1]) });
       }
     }
-    // Map every CODIGOESTACION code → its deduplicated Station object
-    for (let s of rawStations.features) {
+
+    // Map CODIGOESTACION → StationInfo
+    for (const s of rawStations.features) {
       const code = s.properties.CODIGOESTACION?.toString();
       if (code) {
-        const station = this.stations.find(x => x.name === s.properties.DENOMINACION);
-        if (station) this.stationsByCode.set(code, station);
+        const info = this.stations.find(x => x.name === s.properties.DENOMINACION);
+        if (info) this.stationsByCode.set(code, info);
       }
     }
   }

--- a/metro/src/app/services/canvas-viewport.service.spec.ts
+++ b/metro/src/app/services/canvas-viewport.service.spec.ts
@@ -1,0 +1,90 @@
+import { TestBed } from '@angular/core/testing';
+import { CanvasViewportService } from './canvas-viewport.service';
+
+describe('CanvasViewportService', () => {
+  let svc: CanvasViewportService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [CanvasViewportService] });
+    svc = TestBed.inject(CanvasViewportService);
+    svc.init(1);
+  });
+
+  it('starts at scale=1, panX=0, panY=0', () => {
+    expect(svc.scale()).toBe(1);
+    expect(svc.panX()).toBe(0);
+    expect(svc.panY()).toBe(0);
+  });
+
+  describe('computeFit', () => {
+    it('centers the bounding box in the viewport', () => {
+      svc.computeFit({ minX: 0, minY: 0, maxX: 100, maxY: 50 }, 200, 100, 0);
+      // fit = min(200/100, 100/50) = min(2, 2) = 2
+      expect(svc.scale()).toBeCloseTo(2);
+      expect(svc.fitScale()).toBeCloseTo(2);
+      // panX = (200 - 100*2)/2 - 0*2 = 0
+      expect(svc.panX()).toBeCloseTo(0);
+      // panY = (100 - 50*2)/2 - 0*2 = 0
+      expect(svc.panY()).toBeCloseTo(0);
+    });
+
+    it('applies margin correctly', () => {
+      svc.computeFit({ minX: 0, minY: 0, maxX: 100, maxY: 100 }, 120, 120, 10);
+      // fit = (120-20)/100 = 1
+      expect(svc.scale()).toBeCloseTo(1);
+    });
+  });
+
+  describe('zoomAt', () => {
+    beforeEach(() => svc.computeFit({ minX: 0, minY: 0, maxX: 100, maxY: 100 }, 200, 200, 0));
+
+    it('increases scale when zooming in', () => {
+      const before = svc.scale();
+      svc.zoomAt(2, 100, 100);
+      expect(svc.scale()).toBeCloseTo(before * 2);
+    });
+
+    it('preserves the anchor point position after zoom', () => {
+      // Before zoom: canvas coords at screen point (50,50)
+      const anchorX = 50, anchorY = 50;
+      const canvasXBefore = (anchorX - svc.panX()) / svc.scale();
+      const canvasYBefore = (anchorY - svc.panY()) / svc.scale();
+      svc.zoomAt(2, anchorX, anchorY);
+      // After zoom: same canvas point should project to same screen point
+      const canvasXAfter = (anchorX - svc.panX()) / svc.scale();
+      const canvasYAfter = (anchorY - svc.panY()) / svc.scale();
+      expect(canvasXAfter).toBeCloseTo(canvasXBefore, 5);
+      expect(canvasYAfter).toBeCloseTo(canvasYBefore, 5);
+    });
+
+    it('clamps scale to fitScale*0.5 minimum', () => {
+      const fit = svc.fitScale();
+      svc.zoomAt(0.001, 0, 0);
+      expect(svc.scale()).toBeCloseTo(fit * 0.5);
+    });
+
+    it('clamps scale to fitScale*50 maximum', () => {
+      const fit = svc.fitScale();
+      svc.zoomAt(1000, 0, 0);
+      expect(svc.scale()).toBeCloseTo(fit * 50);
+    });
+  });
+
+  describe('pan', () => {
+    it('shifts panX and panY', () => {
+      svc.pan(10, -5);
+      expect(svc.panX()).toBe(10);
+      expect(svc.panY()).toBe(-5);
+      svc.pan(3, 2);
+      expect(svc.panX()).toBe(13);
+      expect(svc.panY()).toBe(-3);
+    });
+  });
+
+  describe('zoomReadout', () => {
+    it('shows ×1.00 at fit scale', () => {
+      svc.computeFit({ minX: 0, minY: 0, maxX: 100, maxY: 100 }, 200, 200, 0);
+      expect(svc.zoomReadout()).toBe('×1.00');
+    });
+  });
+});

--- a/metro/src/app/services/metro-data.service.spec.ts
+++ b/metro/src/app/services/metro-data.service.spec.ts
@@ -19,8 +19,8 @@ describe('MetroDataService', () => {
   });
 
   it('should load paths', () => {
-    expect(service.paths).toBeDefined();
-    expect(service.paths.length).toBeGreaterThan(0);
+    expect(service.segments).toBeDefined();
+    expect(service.segments.length).toBeGreaterThan(0);
   });
 
   it('stations should have name and position', () => {
@@ -32,7 +32,7 @@ describe('MetroDataService', () => {
   });
 
   it('paths should have line and path coordinates', () => {
-    const path = service.paths[0];
+    const path = service.segments[0];
     expect(path.line).toBeDefined();
     expect(path.path).toBeDefined();
     expect(path.path.length).toBeGreaterThan(0);

--- a/metro/src/app/services/metro-data.service.ts
+++ b/metro/src/app/services/metro-data.service.ts
@@ -1,22 +1,22 @@
 import { Injectable } from '@angular/core';
 
-import { Madrid } from '../madrid';
-import { Station } from '../station';
+import { Madrid, StationInfo } from '../madrid';
+import { Segment } from '../domain/segment';
 import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../constants';
 import rawPaths from '../../assets/tramos.json';
 
 @Injectable({ providedIn: 'root' })
 export class MetroDataService {
 
-  readonly stations: Station[];
-  readonly paths: Station[];
-  readonly stationsByCode: Map<string, Station>;
+  readonly stations: StationInfo[];
+  readonly segments: Segment[];
+  readonly stationsByCode: Map<string, StationInfo>;
   readonly lineDestinations: Map<string, string>;
 
   constructor() {
     const madrid = new Madrid(CANVAS_WIDTH, CANVAS_HEIGHT);
     this.stations = madrid.stations;
-    this.paths = madrid.paths;
+    this.segments = madrid.segments;
     this.stationsByCode = madrid.stationsByCode;
 
     // Build map: "line/sentido" → terminal station name (highest NUMEROORDEN)

--- a/metro/src/app/services/metro-renderer.service.ts
+++ b/metro/src/app/services/metro-renderer.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 
 import { Train } from '../train';
+import { TrainView } from '../train-view';
 import { TrackedPerson } from './simulation-state.service';
 import { MetroDataService } from './metro-data.service';
 import { SimulationConfigService } from './simulation-config.service';
@@ -47,7 +48,7 @@ export class MetroRendererService {
     const scale  = this.viewport.scale();
 
     ctx.globalAlpha = 0.18;
-    for (const seg of this.metroData.paths) {
+    for (const seg of this.metroData.segments) {
       if (seg.path.length < 2) continue;
       ctx.beginPath();
       ctx.moveTo(seg.path[0].x, seg.path[0].y);
@@ -59,7 +60,7 @@ export class MetroRendererService {
     ctx.globalAlpha = 1;
 
     ctx.lineWidth = PATH_WIDTH_PX / scale;
-    for (const seg of this.metroData.paths) {
+    for (const seg of this.metroData.segments) {
       if (seg.path.length < 2) continue;
       ctx.beginPath();
       ctx.moveTo(seg.path[0].x, seg.path[0].y);
@@ -91,6 +92,7 @@ export class MetroRendererService {
   drawTrains(
     ctx:      CanvasRenderingContext2D,
     trains:   Train[],
+    views:    ReadonlyMap<string, TrainView>,
     now:      number,
     hovered:  string | null,
     selected: string | null,
@@ -107,6 +109,8 @@ export class MetroRendererService {
     const trainSizeRatio = Math.max(1.0, Math.min(rawRatio, capRatio));
 
     for (const train of trains) {
+      const view = views.get(train.id);
+      if (!view) continue;
       const wagons    = TRAIN_WAGONS[train.line] ?? DEFAULT_WAGONS;
       const stride    = WAGON_W + WAGON_GAP;
       const halfLen   = (wagons - 1) / 2 * stride;
@@ -118,40 +122,40 @@ export class MetroRendererService {
       const r         = WAGON_H * 0.3;
       const inset     = 0.25;
 
-      const hasPath = train.pathPoints.length >= 2 && train.pathArcLens.length >= 2;
+      const hasPath = view.pathPoints.length >= 2 && view.pathArcLens.length >= 2;
 
       let centerArc = 0;
       let centerSegIdx = 1;
       if (hasPath) {
-        const segStart  = train.pathSegStart;
-        const segEnd    = train.pathSegEnd;
-        const lensTotal = train.pathArcLens[train.pathArcLens.length - 1];
-        if (train.travelMs > 0) {
-          const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
+        const segStart  = view.pathSegStart;
+        const segEnd    = view.pathSegEnd;
+        const lensTotal = view.pathArcLens[view.pathArcLens.length - 1];
+        if (view.travelMs > 0) {
+          const t    = Math.min(1, (now - view.departedAt) / view.travelMs);
           const ease = t * t * (3 - 2 * t);
           centerArc  = segStart + ease * (segEnd - segStart);
         } else {
           centerArc = segEnd;
         }
         centerArc = Math.max(effHalf, Math.min(lensTotal - effHalf, centerArc));
-        const c = positionAtArc(train.pathPoints, train.pathArcLens, centerArc);
-        train.x = c.x; train.y = c.y; train.heading = c.heading;
+        const c = positionAtArc(view.pathPoints, view.pathArcLens, centerArc);
+        view.x = c.x; view.y = c.y; view.heading = c.heading;
         centerSegIdx = c.segIdx;
-      } else if (train.travelMs > 0) {
-        const t    = Math.min(1, (now - train.departedAt) / train.travelMs);
+      } else if (view.travelMs > 0) {
+        const t    = Math.min(1, (now - view.departedAt) / view.travelMs);
         const ease = t * t * (3 - 2 * t);
-        train.x = train.fromX + (train.targetX - train.fromX) * ease;
-        train.y = train.fromY + (train.targetY - train.fromY) * ease;
+        view.x = view.fromX + (view.targetX - view.fromX) * ease;
+        view.y = view.fromY + (view.targetY - view.fromY) * ease;
       }
 
       for (let i = wagons - 1; i >= 0; i--) {
         const arcOffset = (i - (wagons - 1) / 2) * effStride;
         let wx: number, wy: number, wh: number;
         if (hasPath) {
-          const p = positionAtArc(train.pathPoints, train.pathArcLens, centerArc + arcOffset, centerSegIdx);
+          const p = positionAtArc(view.pathPoints, view.pathArcLens, centerArc + arcOffset, centerSegIdx);
           wx = p.x; wy = p.y; wh = p.heading;
         } else {
-          wx = train.x; wy = train.y; wh = train.heading;
+          wx = view.x; wy = view.y; wh = view.heading;
         }
 
         ctx.save();
@@ -179,12 +183,12 @@ export class MetroRendererService {
       const arrowArc = centerArc + trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
       let ax: number, ay: number, ah: number;
       if (hasPath) {
-        const ap = positionAtArc(train.pathPoints, train.pathArcLens, arrowArc, centerSegIdx);
+        const ap = positionAtArc(view.pathPoints, view.pathArcLens, arrowArc, centerSegIdx);
         ax = ap.x; ay = ap.y; ah = ap.heading;
       } else {
-        ax = train.x + Math.cos(train.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
-        ay = train.y + Math.sin(train.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
-        ah = train.heading;
+        ax = view.x + Math.cos(view.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
+        ay = view.y + Math.sin(view.heading) * trainSizeRatio * (halfLen + WAGON_W / 2 + arrowH);
+        ah = view.heading;
       }
       ctx.save();
       ctx.translate(ax, ay); ctx.rotate(ah); ctx.scale(trainSizeRatio, trainSizeRatio);
@@ -197,7 +201,7 @@ export class MetroRendererService {
 
     // Hover ring
     if (hovered && hovered !== selected) {
-      const ht = trains.find(t => t.id === hovered);
+      const ht = views.get(hovered);
       if (ht) {
         ctx.save();
         ctx.beginPath();
@@ -211,7 +215,7 @@ export class MetroRendererService {
 
     // Selected ring
     if (selected) {
-      const st = trains.find(t => t.id === selected);
+      const st = views.get(selected);
       if (st) {
         ctx.save();
         ctx.beginPath();

--- a/metro/src/app/services/path-geometry.service.spec.ts
+++ b/metro/src/app/services/path-geometry.service.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { PathGeometryService } from './path-geometry.service';
+import { MetroDataService } from './metro-data.service';
+import { Segment } from '../domain/segment';
+
+function makeSeg(id: string, line: string, sentido: string,
+                 path: { x: number; y: number }[]): Segment {
+  return { id, name: id, line, sentido, path,
+           position: path[path.length - 1], longitudM: 0, velocidadKmh: 0 };
+}
+
+describe('PathGeometryService', () => {
+  let svc: PathGeometryService;
+
+  const seg1 = makeSeg('1', 'L1', 'A', [{ x: 0, y: 0 }, { x: 5, y: 0 }]);
+  const seg2 = makeSeg('2', 'L1', 'A', [{ x: 5, y: 0 }, { x: 10, y: 0 }]);
+  const seg3 = makeSeg('3', 'L1', 'A', [{ x: 10, y: 0 }, { x: 15, y: 0 }]);
+  const detached = makeSeg('4', 'L1', 'A', [{ x: 100, y: 100 }, { x: 200, y: 100 }]);
+
+  const mockMetroData = { segments: [seg1, seg2, seg3, detached], stationsByCode: new Map() };
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        PathGeometryService,
+        { provide: MetroDataService, useValue: mockMetroData },
+      ],
+    });
+    svc = TestBed.inject(PathGeometryService);
+  });
+
+  describe('buildCompositePath', () => {
+    it('isolated segment returns its own path with correct segStart/segEnd', () => {
+      const r = svc.buildCompositePath(makeSeg('x', 'L2', 'B', [{ x: 0, y: 0 }, { x: 1, y: 0 }]));
+      expect(r.path.length).toBe(2);
+      expect(r.segStart).toBeCloseTo(0);
+      expect(r.segEnd).toBeCloseTo(1);
+    });
+
+    it('prepends prev segment when connected', () => {
+      const r = svc.buildCompositePath(seg2);
+      // seg1 connects to seg2 (seg1.end = {5,0} = seg2.start)
+      expect(r.path[0]).toEqual({ x: 0, y: 0 });
+      expect(r.segStart).toBeCloseTo(5); // length of seg1
+    });
+
+    it('appends next segment when connected', () => {
+      const r = svc.buildCompositePath(seg2);
+      // seg3 starts at {10,0} = seg2.end
+      const lastPt = r.path[r.path.length - 1];
+      expect(lastPt).toEqual({ x: 15, y: 0 });
+    });
+
+    it('does not connect detached segment (gap > CONNECT_SQ)', () => {
+      const r = svc.buildCompositePath(detached);
+      expect(r.path.length).toBe(2);
+      expect(r.path[0]).toEqual({ x: 100, y: 100 });
+    });
+  });
+
+  describe('buildPersonRailPath', () => {
+    it('returns empty array for empty nodes', () => {
+      expect(svc.buildPersonRailPath([])).toEqual([]);
+    });
+
+    it('ignores station nodes', () => {
+      expect(svc.buildPersonRailPath(['Station_X'])).toEqual([]);
+    });
+
+    it('builds path from platform nodes matching segments', () => {
+      const pts = svc.buildPersonRailPath(['Platform_1']);
+      expect(pts.length).toBe(2);
+      expect(pts[0]).toEqual({ x: 0, y: 0 });
+    });
+  });
+});

--- a/metro/src/app/services/path-geometry.service.ts
+++ b/metro/src/app/services/path-geometry.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@angular/core';
 
 import { TrackedPerson } from './simulation-state.service';
 import { MetroDataService } from './metro-data.service';
+import { Segment } from '../domain/segment';
 import { NodeId } from '../utils/node-id';
 import { computeArcLens } from '../utils/path-geometry';
-
-type Segment = MetroDataService['paths'][number];
+import { CONNECT_SQ } from '../constants';
 
 @Injectable({ providedIn: 'root' })
 export class PathGeometryService {
@@ -14,14 +14,13 @@ export class PathGeometryService {
   buildCompositePath(
     seg: Segment,
   ): { path: { x: number; y: number }[]; segStart: number; segEnd: number } {
-    const CONNECT_SQ = 4;
     const usedIds = new Set<string>([seg.id]);
 
     let prepended: { x: number; y: number }[] = [];
     let searchFrom = seg.path[0];
     for (let k = 0; k < 2; k++) {
       let best = CONNECT_SQ, prev: Segment | null = null;
-      for (const s of this.metroData.paths) {
+      for (const s of this.metroData.segments) {
         if (s.line !== seg.line || s.sentido !== seg.sentido) continue;
         if (usedIds.has(s.id) || s.path.length < 2) continue;
         const e = s.path[s.path.length - 1];
@@ -38,7 +37,7 @@ export class PathGeometryService {
     const segTail = seg.path[seg.path.length - 1];
     {
       let best = CONNECT_SQ, next: Segment | null = null;
-      for (const s of this.metroData.paths) {
+      for (const s of this.metroData.segments) {
         if (s.line !== seg.line || s.sentido !== seg.sentido) continue;
         if (usedIds.has(s.id) || s.path.length < 2) continue;
         const d = (s.path[0].x - segTail.x) ** 2 + (s.path[0].y - segTail.y) ** 2;
@@ -59,7 +58,7 @@ export class PathGeometryService {
     for (const node of nodes) {
       if (!NodeId.isPlatform(node)) continue;
       const code = NodeId.parse(node)!.code;
-      const tramo = this.metroData.paths.find(p => p.id === code);
+      const tramo = this.metroData.segments.find(p => p.id === code);
       if (!tramo || tramo.path.length < 2) continue;
       if (points.length === 0) {
         points.push(...tramo.path);
@@ -84,7 +83,7 @@ export class PathGeometryService {
       return s ? s.position : null;
     }
     if (parsed?.kind === 'platform') {
-      const seg = this.metroData.paths.find(p => p.id === parsed.code);
+      const seg = this.metroData.segments.find(p => p.id === parsed.code);
       return seg ? seg.position : null;
     }
     return null;
@@ -94,7 +93,7 @@ export class PathGeometryService {
     const loc = tracked?.loc;
     if (!loc) return null;
     if (loc.type === 'platform') {
-      const seg = this.metroData.paths.find(p => p.id === loc.id);
+      const seg = this.metroData.segments.find(p => p.id === loc.id);
       return seg ? seg.position : null;
     }
     if (loc.type === 'station') {

--- a/metro/src/app/services/simulation-state.service.spec.ts
+++ b/metro/src/app/services/simulation-state.service.spec.ts
@@ -69,7 +69,7 @@ describe('SimulationStateService', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.process({ message: 'newTrain', train: 'T1', x: 100, y: 200 });
     expect(service.trains().length).toBe(1);
-    expect(service.getTrain('T1')!.targetX).toBe(100);
+    expect(service.getTrainView('T1')!.targetX).toBe(100);
   });
 
   it('getTrain should return train after newTrain', () => {
@@ -83,8 +83,8 @@ describe('SimulationStateService', () => {
   it('process moveTrain should update target position', () => {
     service.process({ message: 'newTrain', train: 'T1', x: 0, y: 0 });
     service.process({ message: 'moveTrain', train: 'T1', x: 50, y: 75 });
-    expect(service.trains()[0].targetX).toBe(50);
-    expect(service.trains()[0].targetY).toBe(75);
+    expect(service.getTrainView(service.trains()[0].id)!.targetX).toBe(50);
+    expect(service.getTrainView(service.trains()[0].id)!.targetY).toBe(75);
   });
 
   it('process moveTrain for unknown train should not add it', () => {

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, signal, computed } from '@angular/core';
 
 import { Train } from '../train';
+import { TrainView, makeTrainView } from '../train-view';
 import { PathResult, SimulationMessage } from '../messages';
 import { pathQuerySummary } from '../utils/path-summary';
 
@@ -13,12 +14,17 @@ export interface TrackedPerson {
 @Injectable({ providedIn: 'root' })
 export class SimulationStateService {
 
-  // ── Trains ─────────────────────────────────────────────────────────────────
+  // ── Trains (domain) ────────────────────────────────────────────────────────
   private readonly _trainsMap = new Map<string, Train>();
   private readonly _trainsSignal = signal<ReadonlyMap<string, Train>>(new Map());
   readonly trains = computed(() => Array.from(this._trainsSignal().values()));
 
   getTrain(id: string): Train | undefined { return this._trainsMap.get(id); }
+
+  // ── Train views (render state, mutable by renderer) ────────────────────────
+  private readonly _trainViewsMap = new Map<string, TrainView>();
+  getTrainView(id: string): TrainView | undefined { return this._trainViewsMap.get(id); }
+  getTrainViews(): ReadonlyMap<string, TrainView> { return this._trainViewsMap; }
 
   // ── People counts ──────────────────────────────────────────────────────────
   readonly simulationPeople = signal(0);
@@ -73,6 +79,7 @@ export class SimulationStateService {
 
   reset(): void {
     this._trainsMap.clear();
+    this._trainViewsMap.clear();
     this._trainsSignal.set(new Map());
     this.simulationPeople.set(0);
     this.metroPeople.set(0);
@@ -96,13 +103,14 @@ export class SimulationStateService {
     switch (msg.message) {
       case 'moveTrain': {
         const train = this._trainsMap.get(msg.train);
-        if (train) {
-          train.fromX = train.x;
-          train.fromY = train.y;
-          train.targetX = msg.x;
-          train.targetY = msg.y;
-          train.departedAt = performance.now();
-          train.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
+        const view  = this._trainViewsMap.get(msg.train);
+        if (train && view) {
+          view.fromX = view.x;
+          view.fromY = view.y;
+          view.targetX = msg.x;
+          view.targetY = msg.y;
+          view.departedAt = performance.now();
+          view.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
           if (msg.people   !== undefined) train.people   = msg.people;
           if (msg.capacity !== undefined) train.capacity = msg.capacity;
           if (msg.anden    !== undefined) train.anden    = msg.anden;
@@ -112,26 +120,29 @@ export class SimulationStateService {
       }
       case 'newTrain': {
         const existing = this._trainsMap.get(msg.train);
-        if (existing) {
-          existing.fromX = existing.x;
-          existing.fromY = existing.y;
-          existing.targetX = msg.x;
-          existing.targetY = msg.y;
-          existing.departedAt = performance.now();
-          existing.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
+        const viewExisting = this._trainViewsMap.get(msg.train);
+        if (existing && viewExisting) {
+          viewExisting.fromX = viewExisting.x;
+          viewExisting.fromY = viewExisting.y;
+          viewExisting.targetX = msg.x;
+          viewExisting.targetY = msg.y;
+          viewExisting.departedAt = performance.now();
+          viewExisting.travelMs = msg.travelMs ?? 135_000 * this.timeMultiplier();
           if (msg.people   !== undefined) existing.people   = msg.people;
           if (msg.capacity !== undefined) existing.capacity = msg.capacity;
           if (msg.anden    !== undefined) existing.anden    = msg.anden;
         } else {
-          const t = new Train(msg.train, msg.x, msg.y, msg.people ?? 0, msg.capacity ?? 600);
+          const t = new Train(msg.train, msg.people ?? 0, msg.capacity ?? 600);
           if (msg.anden !== undefined) t.anden = msg.anden;
           this._trainsMap.set(msg.train, t);
+          this._trainViewsMap.set(msg.train, makeTrainView(msg.train, msg.x, msg.y));
         }
         this._trainsSignal.set(new Map(this._trainsMap));
         break;
       }
       case 'removeTrain': {
         this._trainsMap.delete(msg.train);
+        this._trainViewsMap.delete(msg.train);
         this._trainsSignal.set(new Map(this._trainsMap));
         break;
       }

--- a/metro/src/app/services/tile.service.spec.ts
+++ b/metro/src/app/services/tile.service.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { TileService } from './tile.service';
+
+describe('TileService', () => {
+  let svc: TileService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    svc = TestBed.inject(TileService);
+  });
+
+  describe('zoomFor', () => {
+    it('returns 12 at very small scale', () => expect(svc.zoomFor(0.1)).toBe(12));
+    it('returns 13 between 0.3 and 0.7', () => expect(svc.zoomFor(0.5)).toBe(13));
+    it('returns 14 between 0.7 and 1.5', () => expect(svc.zoomFor(1.0)).toBe(14));
+    it('returns 15 between 1.5 and 3', () => expect(svc.zoomFor(2.0)).toBe(15));
+    it('returns 16 above 3', () => expect(svc.zoomFor(5.0)).toBe(16));
+  });
+
+  describe('getTile', () => {
+    it('returns null on first request (loads asynchronously)', () => {
+      const result = svc.getTile(14, 8073, 6119, () => {});
+      expect(result).toBeNull();
+    });
+
+    it('caches the tile on second call after image creation', () => {
+      svc.getTile(14, 8073, 6119, () => {});
+      const second = svc.getTile(14, 8073, 6119, () => {});
+      // Second call should return the cached (possibly incomplete) image object
+      expect(second).not.toBeNull();
+    });
+  });
+});

--- a/metro/src/app/train-view.ts
+++ b/metro/src/app/train-view.ts
@@ -1,0 +1,22 @@
+export interface TrainView {
+  id: string;
+  x: number;
+  y: number;
+  fromX: number;
+  fromY: number;
+  targetX: number;
+  targetY: number;
+  departedAt: number;
+  travelMs: number;
+  pathPoints: { x: number; y: number }[];
+  pathArcLens: number[];
+  pathSegStart: number;
+  pathSegEnd: number;
+  heading: number;
+}
+
+export function makeTrainView(id: string, x: number, y: number): TrainView {
+  return { id, x, y, fromX: x, fromY: y, targetX: x, targetY: y,
+           departedAt: 0, travelMs: 0, pathPoints: [], pathArcLens: [],
+           pathSegStart: 0, pathSegEnd: 0, heading: 0 };
+}

--- a/metro/src/app/train.ts
+++ b/metro/src/app/train.ts
@@ -1,43 +1,15 @@
-
 export class Train {
   id: string;
-  x: number;
-  y: number;
-  fromX: number;
-  fromY: number;
-  targetX: number;
-  targetY: number;
-  departedAt: number;
-  travelMs: number;
   people: number;
   capacity: number;
-  anden: number;
-  // Path geometry for track-following animation
-  pathPoints: { x: number; y: number }[];
-  pathArcLens: number[];   // cached cumulative arc lengths for pathPoints
-  pathSegStart: number;    // arc position where the current tramo starts inside composite
-  pathSegEnd: number;      // arc position where the current tramo ends inside composite
-  heading: number;
   line: string;
+  anden: number;
 
-  constructor(id: string, x: number, y: number, people = 0, capacity = 600) {
+  constructor(id: string, people = 0, capacity = 600) {
     this.id = id;
-    this.x = x;
-    this.y = y;
-    this.fromX = x;
-    this.fromY = y;
-    this.targetX = x;
-    this.targetY = y;
-    this.departedAt = 0;
-    this.travelMs = 0;
     this.people = people;
     this.capacity = capacity;
-    this.anden = 0;
-    this.pathPoints = [];
-    this.pathArcLens = [];
-    this.pathSegStart = 0;
-    this.pathSegEnd = 0;
-    this.heading = 0;
     this.line = '';
+    this.anden = 0;
   }
 }

--- a/metro/src/app/train/person-tracker/person-tracker.component.ts
+++ b/metro/src/app/train/person-tracker/person-tracker.component.ts
@@ -30,7 +30,7 @@ export class PersonTrackerComponent {
       return this.metroData.stationsByCode.get(code)?.name ?? code;
     }
     if (lt === 'platform') {
-      return this.metroData.paths.find(p => p.id === lid)?.name ?? `andén ${lid}`;
+      return this.metroData.segments.find(p => p.id === lid)?.name ?? `andén ${lid}`;
     }
     if (lt === 'train') {
       const t = this.state.getTrain(lid);

--- a/metro/src/app/train/train.component.spec.ts
+++ b/metro/src/app/train/train.component.spec.ts
@@ -19,7 +19,7 @@ describe('TrainComponent', () => {
   };
   const mockMetroDataService = {
     stations: [],
-    paths: [],
+    segments: [],
     lineDestinations: new Map<string, string>(),
   };
   const mockSimulationStateService = {

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -13,7 +13,7 @@ import { PathGeometryService } from '../services/path-geometry.service';
 import { MetroRendererService } from '../services/metro-renderer.service';
 import { SimulationClockService } from '../services/simulation-clock.service';
 import { TileService } from '../services/tile.service';
-import { TRAIN_WAGONS, DEFAULT_WAGONS, WAGON_W, WAGON_H, WAGON_GAP } from '../constants';
+import { TRAIN_WAGONS, DEFAULT_WAGONS, WAGON_W, WAGON_H, WAGON_GAP, TRAIN_HIT_PX, STATION_HIT_PX, CD_TICK_MS } from '../constants';
 import { lineColor, fmtCount, groupByDest } from '../utils/format';
 import { NodeId } from '../utils/node-id';
 import { computeArcLens } from '../utils/path-geometry';
@@ -124,7 +124,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     private readonly renderer: MetroRendererService,
     private readonly tileService: TileService,
   ) {
-    const lines = new Set(this.metroData.paths.map(p => p.line));
+    const lines = new Set(this.metroData.segments.map(p => p.line));
     this.state.initLines(Array.from(lines));
   }
 
@@ -161,19 +161,20 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
         this.state.process(msg);
         if ((msg.message === 'newTrain' || msg.message === 'moveTrain') && msg.anden != null) {
           const train = this.state.getTrain(msg.train);
-          if (train) {
-            const seg = this.metroData.paths.find(s => s.id === String(msg.anden));
+          const view  = this.state.getTrainView(msg.train);
+          if (train && view) {
+            const seg = this.metroData.segments.find(s => s.id === String(msg.anden));
             if (seg && seg.path.length >= 2) {
               const { path, segStart, segEnd } = this.pathGeo.buildCompositePath(seg);
-              train.pathPoints    = path;
-              train.pathArcLens   = computeArcLens(path);
-              train.pathSegStart  = segStart;
-              train.pathSegEnd    = segEnd;
-              train.line = seg.line;
+              view.pathPoints   = path;
+              view.pathArcLens  = computeArcLens(path);
+              view.pathSegStart = segStart;
+              view.pathSegEnd   = segEnd;
+              train.line     = seg.line;
               train.capacity = (TRAIN_WAGONS[seg.line] ?? DEFAULT_WAGONS) * this.cfg.config.wagonCapacity;
               const last = path[path.length - 1];
               const prev = path[path.length - 2];
-              train.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
+              view.heading = Math.atan2(last.y - prev.y, last.x - prev.x);
             }
           }
         }
@@ -209,7 +210,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   private computeFit(): void {
     const container = this.canvasContainer().nativeElement as HTMLElement;
     let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-    for (const s of this.metroData.paths) {
+    for (const s of this.metroData.segments) {
       for (const p of s.path) {
         if (p.x < minX) minX = p.x;
         if (p.y < minY) minY = p.y;
@@ -299,7 +300,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
       this.updateTrainPanel();
       this.needsTrainRedraw = false;
 
-      if (timestamp - this.lastCdTick >= 200) {
+      if (timestamp - this.lastCdTick >= CD_TICK_MS) {
         this.lastCdTick = timestamp;
         const next = this.state.metroPeople();
         this.peopleHistory.update(h => [...h.slice(1), next]);
@@ -347,7 +348,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   private drawPaths(): void { this.renderer.drawPaths(this.ctxPaths); }
 
-  private findNearestStation(cx: number, cy: number, hitPx = 14): number {
+  private findNearestStation(cx: number, cy: number, hitPx = STATION_HIT_PX): number {
     const scale = this.viewport.scale();
     const panX  = this.viewport.panX();
     const panY  = this.viewport.panY();
@@ -361,17 +362,17 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     return bestIdx;
   }
 
-  private findNearestTrain(cx: number, cy: number, hitPx = 24): string | null {
+  private findNearestTrain(cx: number, cy: number, hitPx = TRAIN_HIT_PX): string | null {
     const scale = this.viewport.scale();
     const panX  = this.viewport.panX();
     const panY  = this.viewport.panY();
     let best: string | null = null;
     let bestDist = hitPx * hitPx;
-    for (const t of this.state.trains()) {
-      const tx = t.x * scale + panX;
-      const ty = t.y * scale + panY;
+    for (const v of this.state.getTrainViews().values()) {
+      const tx = v.x * scale + panX;
+      const ty = v.y * scale + panY;
       const d2 = (cx - tx) ** 2 + (cy - ty) ** 2;
-      if (d2 < bestDist) { bestDist = d2; best = t.id; }
+      if (d2 < bestDist) { bestDist = d2; best = v.id; }
     }
     return best;
   }
@@ -401,12 +402,12 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   }
 
   private updateTrainPanel(): void {
-    this.hoveredTrainId = this.findNearestTrain(this._mouseContainerX, this._mouseContainerY, 40);
+    this.hoveredTrainId = this.findNearestTrain(this._mouseContainerX, this._mouseContainerY);
     if (!this.selectedTrainId) return;
-    const t = this.state.getTrain(this.selectedTrainId);
-    if (!t) { this.selectedTrainId = null; return; }
-    this.trainPanelX = t.x * this.viewport.scale() + this.viewport.panX();
-    this.trainPanelY = t.y * this.viewport.scale() + this.viewport.panY();
+    const v = this.state.getTrainView(this.selectedTrainId);
+    if (!v) { this.selectedTrainId = null; return; }
+    this.trainPanelX = v.x * this.viewport.scale() + this.viewport.panX();
+    this.trainPanelY = v.y * this.viewport.scale() + this.viewport.panY();
   }
 
   selectPerson(personId: string): void {
@@ -436,7 +437,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     const lineMap   = new Map<string, string[]>();
     const platformMap = new Map<string, { id: string; sentido: string }[]>();
     const seen = new Map<string, Set<string>>();
-    for (const p of this.metroData.paths) {
+    for (const p of this.metroData.segments) {
       const dirKey = p.line + '/' + p.sentido;
       if (!seen.has(p.name)) seen.set(p.name, new Set());
       if (!seen.get(p.name)!.has(dirKey)) {
@@ -474,6 +475,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     this.renderer.drawTrains(
       this.ctxTrains,
       this.state.trains(),
+      this.state.getTrainViews(),
       now,
       this.hoveredTrainId,
       this.selectedTrainId,
@@ -494,11 +496,11 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     const newSpeed = this.localSpeed;
     const now = performance.now();
     const ratio = oldSpeed / newSpeed;
-    for (const train of this.state.trains()) {
-      if (train.travelMs > 0) {
-        const elapsed = now - train.departedAt;
-        if (elapsed < train.travelMs) {
-          train.travelMs = elapsed + (train.travelMs - elapsed) * ratio;
+    for (const view of this.state.getTrainViews().values()) {
+      if (view.travelMs > 0) {
+        const elapsed = now - view.departedAt;
+        if (elapsed < view.travelMs) {
+          view.travelMs = elapsed + (view.travelMs - elapsed) * ratio;
         }
       }
     }
@@ -532,7 +534,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
 
   get telemetryTrains(): number   { return this.state.trains().length; }
 
-  get telemetrySegments(): number { return this.metroData.paths.length; }
+  get telemetrySegments(): number { return this.metroData.segments.length; }
   get telemetryStations(): number { return this.metroData.stations.length; }
   get telemetryUptime(): number   { return this.clock.uptime(); }
 


### PR DESCRIPTION
Closes #105, #106, #107. Parte del plan #88 (Fases 6 y 7).

## Summary

### #105 — Tests unitarios nuevos
- `canvas-viewport.service.spec.ts` — zoom mantiene anchor, computeFit centra bbox, pan acumula, clamp min/max
- `path-geometry.service.spec.ts` — buildCompositePath: aislado, con prev, con next, con transferencia (gap); buildPersonRailPath
- `tile.service.spec.ts` — zoomFor para escalas conocidas, cache en segunda llamada

### #106 — Domain model: Segment separado de Station; TrainView separado de Train
- **`Segment` interface** (`domain/segment.ts`): `id`, `name`, `line`, `sentido`, `path`, `position`, `longitudM`, `velocidadKmh`. Reemplaza el abuso de `Station` para tramos.
- **`MetroDataService`**: `paths: Station[]` → `segments: Segment[]`. `Madrid` reescrito con `lonLatToCanvas` directamente (elimina dependencia de `Position`/`Station` para tramos).
- **`TrainView` interface** (`train-view.ts`): separa estado de render (`x`, `y`, `fromX`, `fromY`, `targetX`, `targetY`, `departedAt`, `travelMs`, `pathPoints`, `pathArcLens`, `pathSegStart`, `pathSegEnd`, `heading`) de `Train` (dominio: `id`, `people`, `capacity`, `line`, `anden`).
- `SimulationStateService` mantiene `_trainViewsMap` separado con `getTrainView(id)` y `getTrainViews()`.
- `MetroRendererService.drawTrains()` recibe `Train[]` (dominio) + `ReadonlyMap<string, TrainView>` (render) por separado.
- `train.component.ts`: `findNearestTrain` y `updateTrainPanel` usan `getTrainViews()` para posición.

### #107 — Quick wins: constantes mágicas
- Añadidas a `constants.ts`: `TRAIN_HIT_PX=40`, `STATION_HIT_PX=14`, `CD_TICK_MS=200`, `CONNECT_SQ=4`.
- Usadas en `train.component.ts` y `path-geometry.service.ts`.
- El resto de #107 ya estaba implementado en fases anteriores (listeners via directive, share, dirty, tile URL).

## Test plan

- [ ] `npm run build` sin errores de tipo
- [ ] `npm test` 153/153 verdes
- [ ] Verificar en browser: trenes se mueven correctamente, mapa carga