### PR TITLE
Buddy panel: tracking de usuario con panel de viaje y fixes de visibilidad

### DIFF
--- a/metro-sim/src/main/scala/Simulator.scala
+++ b/metro-sim/src/main/scala/Simulator.scala
@@ -135,6 +135,10 @@ object Simulator {
           case ArrivedToDestination(person) =>
             scribe.debug(s"Person ${person.path.name} arrived to destination")
             people.remove(person.path.name)
+            if (trackedPerson.exists(_.path.name == person.path.name)) {
+              ui ! PersonTrackedArrived(person.path.name)
+              trackedPerson = None
+            }
             Behaviors.same
 
           case TrackPerson(personId) =>

--- a/metro-sim/src/main/scala/UI.scala
+++ b/metro-sim/src/main/scala/UI.scala
@@ -82,6 +82,10 @@ object UI {
           WebSocket.sendText(s"""{"message": "personLocation", "person": "$personId", "locType": "$locType", "locId": "$locId"}""")
           Behaviors.same
 
+        case PersonTrackedArrived(personId) =>
+          WebSocket.sendText(s"""{"message": "personArrived", "person": "$personId"}""")
+          Behaviors.same
+
         case PlatformOvercrowded(platformId, people) =>
           scribe.debug(s"There are $people people in platform $platformId")
           WebSocket.sendText(

--- a/metro-sim/src/main/scala/messages/Messages.scala
+++ b/metro-sim/src/main/scala/messages/Messages.scala
@@ -79,6 +79,7 @@ object Messages {
   case class PersonsInPlatform(anderId: String, persons: List[(String, String)]) extends UIMessage
   case class PersonPlanPath(personId: String, nodes: List[String]) extends UIMessage
   case class PersonTrackerUpdate(personId: String, locType: String, locId: String) extends UIMessage
+  case class PersonTrackedArrived(personId: String) extends UIMessage
 
   // ─── Simulator messages (sent TO the Simulator actor) ────────────────────
   sealed trait SimulatorMessage

--- a/metro/src/app/messages.ts
+++ b/metro/src/app/messages.ts
@@ -129,6 +129,11 @@ export interface PersonLocation {
   locId: string;
 }
 
+export interface PersonArrived {
+  message: 'personArrived';
+  person: string;
+}
+
 // ── Path-query debug types ────────────────────────────────────────────────────
 
 /** A single node returned in a pathResult response. */
@@ -203,4 +208,5 @@ export type SimulationMessage =
   | PersonsInPlatform
   | PersonPath
   | PersonLocation
+  | PersonArrived
   | PathResult;

--- a/metro/src/app/services/metro-renderer.service.ts
+++ b/metro/src/app/services/metro-renderer.service.ts
@@ -241,7 +241,7 @@ export class MetroRendererService {
         ctx.stroke();
         ctx.restore();
       }
-      const locPos = this.pathGeo.resolveLocToPos(tracked);
+      const locPos = this.pathGeo.resolveLocToPos(tracked, views);
       if (locPos) {
         const r = 7 / scale;
         ctx.save();

--- a/metro/src/app/services/path-geometry.service.ts
+++ b/metro/src/app/services/path-geometry.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 
 import { TrackedPerson } from './simulation-state.service';
 import { MetroDataService } from './metro-data.service';
+import { TrainView } from '../train-view';
 import { Segment } from '../domain/segment';
 import { NodeId } from '../utils/node-id';
 import { computeArcLens } from '../utils/path-geometry';
@@ -89,7 +90,10 @@ export class PathGeometryService {
     return null;
   }
 
-  resolveLocToPos(tracked: TrackedPerson | null): { x: number; y: number } | null {
+  resolveLocToPos(
+    tracked: TrackedPerson | null,
+    trainViews?: ReadonlyMap<string, TrainView>,
+  ): { x: number; y: number } | null {
     const loc = tracked?.loc;
     if (!loc) return null;
     if (loc.type === 'platform') {
@@ -99,6 +103,10 @@ export class PathGeometryService {
     if (loc.type === 'station') {
       const s = this.metroData.stationsByCode.get(NodeId.parse(loc.id)?.code ?? loc.id);
       return s ? s.position : null;
+    }
+    if (loc.type === 'train' && trainViews) {
+      const v = trainViews.get(loc.id);
+      return v ? { x: v.x, y: v.y } : null;
     }
     return null;
   }

--- a/metro/src/app/services/simulation-state.service.ts
+++ b/metro/src/app/services/simulation-state.service.ts
@@ -1,18 +1,21 @@
-import { Injectable, signal, computed } from '@angular/core';
+import { Injectable, signal, computed, inject } from '@angular/core';
 
 import { Train } from '../train';
 import { TrainView, makeTrainView } from '../train-view';
 import { PathResult, SimulationMessage } from '../messages';
 import { pathQuerySummary } from '../utils/path-summary';
+import { SimulationClockService } from './simulation-clock.service';
 
 export interface TrackedPerson {
   id: string;
   nodes: string[];
   loc: { type: 'station' | 'platform' | 'train'; id: string } | null;
+  arrivedAtMs?: number;
 }
 
 @Injectable({ providedIn: 'root' })
 export class SimulationStateService {
+  private readonly clock = inject(SimulationClockService);
 
   // ── Trains (domain) ────────────────────────────────────────────────────────
   private readonly _trainsMap = new Map<string, Train>();
@@ -69,8 +72,8 @@ export class SimulationStateService {
     this.stationsPeople.set(new Map(this._stationsPeople));
   }
 
-  trackPerson(id: string): void {
-    this.tracked.set({ id, nodes: [], loc: null });
+  trackPerson(id: string, initialLoc: TrackedPerson['loc'] = null): void {
+    this.tracked.set({ id, nodes: [], loc: initialLoc });
   }
 
   untrackPerson(): void {
@@ -204,6 +207,13 @@ export class SimulationStateService {
         const t = this.tracked();
         if (t && msg.person === t.id) {
           this.tracked.set({ ...t, loc: { type: msg.locType, id: msg.locId } });
+        }
+        break;
+      }
+      case 'personArrived': {
+        const t = this.tracked();
+        if (t && msg.person === t.id) {
+          this.tracked.set({ ...t, arrivedAtMs: this.clock.ms() });
         }
         break;
       }

--- a/metro/src/app/train/buddy-panel/buddy-panel.component.css
+++ b/metro/src/app/train/buddy-panel/buddy-panel.component.css
@@ -1,0 +1,139 @@
+/* ── Host: barra horizontal centrada encima del telemetry strip ── */
+:host {
+  position: absolute;
+  bottom: 58px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 70vw;
+  max-width: calc(100vw - 40px);
+  min-width: 500px;
+  background: rgba(12, 14, 17, 0.92);
+  border: 1px solid var(--line-2);
+  backdrop-filter: blur(12px) saturate(140%);
+  z-index: 20;
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
+  height: 62px;
+  pointer-events: all;
+}
+
+/* ── Segmento genérico ────────────────────────────────────── */
+.bp-seg {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  border-right: 1px solid var(--line-2);
+  flex-shrink: 0;
+  gap: 8px;
+}
+.bp-seg:last-child { border-right: none; }
+
+.bp-seg-body {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3px;
+}
+
+/* ── Etiqueta de sección ─────────────────────────────────── */
+.bp-label {
+  font-size: 7px;
+  letter-spacing: 0.28em;
+  color: var(--t-4);
+  font-weight: 600;
+  line-height: 1;
+}
+
+/* ── ID ──────────────────────────────────────────────────── */
+.bp-seg-id { padding-left: 10px; padding-right: 14px; }
+.bp-live {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--amber);
+  box-shadow: 0 0 5px var(--amber);
+  flex-shrink: 0;
+}
+.bp-id {
+  font-size: 10px; font-family: var(--mono);
+  color: var(--t-1); letter-spacing: 0.08em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ── Ubicación ───────────────────────────────────────────── */
+.bp-seg-loc { min-width: 0; flex: 2 1 130px; }
+.bp-loc-row { display: flex; align-items: center; gap: 5px; min-width: 0; }
+.bp-badge {
+  font-size: 6.5px; letter-spacing: 0.14em; font-weight: 700;
+  padding: 1px 4px; border-radius: 2px; flex-shrink: 0; line-height: 1.5;
+}
+.bp-badge-station  { background: rgba(245,180,84,0.12); color: var(--amber); border: 1px solid var(--amber-dim); }
+.bp-badge-platform { background: rgba(106,217,217,0.10); color: var(--cyan);  border: 1px solid var(--cyan-dim); }
+.bp-badge-train    { background: rgba(74,222,128,0.10);  color: var(--ok);    border: 1px solid rgba(74,222,128,0.35); }
+.bp-loc-name {
+  font-size: 10px; color: var(--t-1); font-family: var(--mono);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+/* ── Trayecto ────────────────────────────────────────────── */
+.bp-seg-route { flex: 2 1 160px; min-width: 0; }
+.bp-route { display: flex; align-items: center; gap: 5px; min-width: 0; }
+.bp-origin, .bp-dest {
+  font-size: 10px; font-family: var(--mono);
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  flex: 1 1 0; min-width: 0;
+}
+.bp-origin { color: var(--t-2); }
+.bp-dest   { color: var(--cyan); }
+.bp-arrow  { font-size: 10px; color: var(--t-4); flex-shrink: 0; }
+
+/* ── Progreso + tiempo ───────────────────────────────────── */
+.bp-seg-progress { width: 120px; flex-shrink: 0; }
+.bp-prog-head { display: flex; justify-content: space-between; align-items: baseline; }
+.bp-elapsed { font-size: 9px; color: var(--amber); font-variant-numeric: tabular-nums; letter-spacing: 0.04em; }
+.bp-prog-row { display: flex; align-items: center; gap: 6px; }
+.bp-prog-track {
+  flex: 1; height: 2px;
+  background: var(--line-2); border-radius: 1px; overflow: hidden;
+}
+.bp-prog-fill {
+  height: 100%; background: var(--amber); border-radius: 1px;
+  transition: width .5s ease;
+  box-shadow: 0 0 5px rgba(245,180,84,0.5);
+}
+.bp-pct {
+  font-size: 9px; color: var(--t-3);
+  font-variant-numeric: tabular-nums; min-width: 26px; text-align: right;
+}
+
+/* ── Próximas paradas ────────────────────────────────────── */
+.bp-seg-stops { flex: 4 1 180px; min-width: 0; }
+.bp-stops { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.bp-stop {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 9px; font-family: var(--mono);
+  color: var(--t-3); opacity: 0.5;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.bp-stop-current { color: var(--t-1); opacity: 1; }
+.bp-stop-dot {
+  width: 4px; height: 4px; border-radius: 50%;
+  border: 1px solid var(--t-4); flex-shrink: 0;
+}
+.bp-stop-current .bp-stop-dot { background: var(--amber); border-color: var(--amber); }
+
+/* ── Botón liberar ───────────────────────────────────────── */
+.bp-seg-action { padding: 0 10px; flex-shrink: 0; border-right: none; }
+.bp-btn-release {
+  padding: 5px 10px; height: 28px;
+  font-size: 7.5px; letter-spacing: 0.2em;
+  color: var(--t-3); background: var(--bg-1);
+  border: 1px solid var(--line-2);
+  cursor: pointer; font-family: var(--mono);
+  white-space: nowrap;
+  transition: color .12s, border-color .12s, background .12s;
+}
+.bp-btn-release:hover {
+  color: var(--crit);
+  border-color: rgba(248,113,113,0.4);
+  background: rgba(248,113,113,0.06);
+}

--- a/metro/src/app/train/buddy-panel/buddy-panel.component.ts
+++ b/metro/src/app/train/buddy-panel/buddy-panel.component.ts
@@ -1,0 +1,211 @@
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+import { UpperCasePipe } from '@angular/common';
+
+import { SimulationStateService } from '../../services/simulation-state.service';
+import { SimulationClockService } from '../../services/simulation-clock.service';
+import { MetroDataService } from '../../services/metro-data.service';
+import { WebSocketService } from '../../services/websocket.service';
+import { NodeId } from '../../utils/node-id';
+
+interface StopItem { name: string; isCurrent: boolean; isTransfer: boolean; }
+
+@Component({
+  selector: 'app-buddy-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [UpperCasePipe],
+  styleUrls: ['./buddy-panel.component.css'],
+  host: { 'class': 'buddy-panel' },
+  template: `
+    <!-- ID -->
+    <div class="bp-seg bp-seg-id">
+      <span class="bp-live"></span>
+      <div class="bp-seg-body">
+        <span class="bp-label">TRACKING</span>
+        <span class="bp-id">#{{ state.tracked()!.id.slice(0, 8) }}</span>
+      </div>
+    </div>
+
+    <!-- Ubicación actual -->
+    <div class="bp-seg bp-seg-loc">
+      <div class="bp-seg-body">
+        <span class="bp-label">UBICACIÓN</span>
+        <div class="bp-loc-row">
+          @if (state.tracked()?.loc?.type) {
+            <span class="bp-badge" [class]="'bp-badge-' + state.tracked()!.loc!.type">
+              {{ state.tracked()!.loc!.type | uppercase }}
+            </span>
+          }
+          <span class="bp-loc-name">{{ locationLabel || '—' }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Trayecto -->
+    <div class="bp-seg bp-seg-route">
+      <div class="bp-seg-body">
+        <span class="bp-label">TRAYECTO</span>
+        <div class="bp-route">
+          <span class="bp-origin">{{ origin || '—' }}</span>
+          <span class="bp-arrow">→</span>
+          <span class="bp-dest">{{ destination || '—' }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Tiempo + Progreso -->
+    <div class="bp-seg bp-seg-progress">
+      <div class="bp-seg-body">
+        <div class="bp-prog-head">
+          <span class="bp-label">PROGRESO</span>
+          <span class="bp-elapsed">{{ elapsedDisplay }}</span>
+        </div>
+        <div class="bp-prog-row">
+          <div class="bp-prog-track">
+            <div class="bp-prog-fill" [style.width.%]="progress"></div>
+          </div>
+          <span class="bp-pct">{{ progress }}%</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Próximas paradas -->
+    @if (upcomingStops.length) {
+      <div class="bp-seg bp-seg-stops">
+        <div class="bp-seg-body">
+          <span class="bp-label">PRÓXIMAS</span>
+          <div class="bp-stops">
+            @for (stop of upcomingStops; track stop.name) {
+              <span class="bp-stop" [class.bp-stop-current]="stop.isCurrent">
+                <span class="bp-stop-dot"></span>
+                {{ stop.name }}{{ stop.isTransfer ? ' ↔' : '' }}
+              </span>
+            }
+          </div>
+        </div>
+      </div>
+    }
+
+    <!-- Acción -->
+    <div class="bp-seg bp-seg-action">
+      <button class="bp-btn-release" (click)="stopTracking()">LIBERAR</button>
+    </div>
+  `,
+})
+export class BuddyPanelComponent {
+  private readonly startMs = this.clock.ms();
+
+  constructor(
+    readonly state: SimulationStateService,
+    private readonly clock: SimulationClockService,
+    private readonly metroData: MetroDataService,
+    private readonly wsService: WebSocketService,
+  ) {}
+
+  get locationLabel(): string {
+    const tracked = this.state.tracked();
+    if (!tracked?.loc) return '';
+    const { type: lt, id: lid } = tracked.loc;
+    if (lt === 'station') {
+      const code = NodeId.parse(lid)?.code ?? lid;
+      return this.metroData.stationsByCode.get(code)?.name ?? code;
+    }
+    if (lt === 'platform') {
+      return this.metroData.segments.find(p => p.id === lid)?.name ?? `andén ${lid}`;
+    }
+    if (lt === 'train') {
+      const t = this.state.getTrain(lid);
+      return t ? `tren L${t.line}` : 'tren';
+    }
+    return '';
+  }
+
+  get elapsedDisplay(): string {
+    const tracked = this.state.tracked();
+    const endMs = tracked?.arrivedAtMs ?? this.clock.ms();
+    const elapsed = Math.max(0, endMs - this.startMs);
+    const totalSec = Math.floor(elapsed / 1000);
+    const h = Math.floor(totalSec / 3600);
+    const m = Math.floor((totalSec % 3600) / 60);
+    const s = totalSec % 60;
+    if (h > 0) return `${h}h ${m.toString().padStart(2, '0')}m`;
+    if (m > 0) return `${m}m ${s.toString().padStart(2, '0')}s`;
+    return `${s}s`;
+  }
+
+  private get stationNodes(): Array<{ code: string; name: string }> {
+    return (this.state.tracked()?.nodes ?? [])
+      .filter(n => NodeId.isStation(n))
+      .map(n => {
+        const code = NodeId.parse(n)!.code;
+        return { code, name: this.metroData.stationsByCode.get(code)?.name ?? code };
+      });
+  }
+
+  get origin(): string { return this.stationNodes[0]?.name ?? ''; }
+  get destination(): string {
+    const ns = this.stationNodes;
+    return ns.length > 1 ? ns[ns.length - 1].name : '';
+  }
+
+  get progress(): number {
+    const tracked = this.state.tracked();
+    if (!tracked?.loc) return 0;
+    const nodes = tracked.nodes;
+    const { type: lt, id: lid } = tracked.loc;
+    if (!nodes.length) return 0;
+    const nodeId = lt === 'station' ? lid : lt === 'platform' ? NodeId.platform(lid) : null;
+    if (!nodeId) return 0;
+    const idx = nodes.indexOf(nodeId);
+    return idx < 0 ? 0 : Math.round((idx / (nodes.length - 1)) * 100);
+  }
+
+  get upcomingStops(): StopItem[] {
+    const tracked = this.state.tracked();
+    if (!tracked?.nodes.length) return [];
+
+    const nodes = tracked.nodes;
+    const loc = tracked.loc;
+    let startIdx = 0;
+    if (loc) {
+      const nodeId = loc.type === 'station' ? loc.id
+        : loc.type === 'platform' ? NodeId.platform(loc.id) : null;
+      if (nodeId) {
+        const idx = nodes.indexOf(nodeId);
+        if (idx >= 0) startIdx = idx;
+      }
+    }
+
+    const lineForPlatform = new Map<string, string>();
+    for (const n of nodes) {
+      if (!NodeId.isPlatform(n)) continue;
+      const code = NodeId.parse(n)!.code;
+      const seg = this.metroData.segments.find(s => s.id === code);
+      if (seg) lineForPlatform.set(n, seg.line);
+    }
+
+    const stops: StopItem[] = [];
+    for (let i = startIdx; i < nodes.length && stops.length < 4; i++) {
+      const n = nodes[i];
+      if (!NodeId.isStation(n)) continue;
+      const code = NodeId.parse(n)!.code;
+      const name = this.metroData.stationsByCode.get(code)?.name ?? code;
+      const isCurrent = i === startIdx && loc?.type === 'station';
+
+      let prevLine = '';
+      for (let k = i - 1; k >= 0; k--) {
+        if (NodeId.isPlatform(nodes[k])) { prevLine = lineForPlatform.get(nodes[k]) ?? ''; break; }
+      }
+      let nextLine = '';
+      for (let k = i + 1; k < nodes.length; k++) {
+        if (NodeId.isPlatform(nodes[k])) { nextLine = lineForPlatform.get(nodes[k]) ?? ''; break; }
+      }
+      stops.push({ name, isCurrent, isTransfer: prevLine !== '' && nextLine !== '' && prevLine !== nextLine });
+    }
+    return stops;
+  }
+
+  stopTracking(): void {
+    this.state.untrackPerson();
+    this.wsService.untrackPerson();
+  }
+}

--- a/metro/src/app/train/platform-inspect/platform-inspect.component.ts
+++ b/metro/src/app/train/platform-inspect/platform-inspect.component.ts
@@ -1,6 +1,7 @@
 import { Component, ChangeDetectionStrategy, ViewEncapsulation, input, output, signal } from '@angular/core';
 
 import { PersonEntry } from '../../messages';
+import { groupByDest } from '../../utils/format';
 
 @Component({
   selector: 'app-platform-inspect',
@@ -22,7 +23,7 @@ import { PersonEntry } from '../../messages';
             @for (pid of group.ids; track pid) {
               <button class="train-person-btn"
                       (mousedown)="$event.stopPropagation()"
-                      (click)="personSelect.emit(pid)">
+                      (click)="personSelect.emit({ personId: pid, platformId: platformId() })">
                 {{ pid.slice(0, 8) }}
               </button>
             }
@@ -40,10 +41,12 @@ import { PersonEntry } from '../../messages';
   `,
 })
 export class PlatformInspectComponent {
-  persons = input.required<PersonEntry[] | undefined>();
+  persons      = input.required<PersonEntry[] | undefined>();
+  platformId   = input.required<string>();
+  destResolver = input<(code: string) => string>(code => code);
 
   closeInspect = output<void>();
-  personSelect = output<string>();
+  personSelect = output<{ personId: string; platformId: string }>();
 
   readonly expandedDest = signal<string | null>(null);
 
@@ -52,13 +55,6 @@ export class PlatformInspectComponent {
   }
 
   groupByDest(persons: PersonEntry[]): Array<{ destination: string; ids: string[] }> {
-    const map = new Map<string, string[]>();
-    for (const p of persons) {
-      if (!map.has(p.destination)) map.set(p.destination, []);
-      map.get(p.destination)!.push(p.id);
-    }
-    return Array.from(map.entries())
-      .map(([destination, ids]) => ({ destination, ids }))
-      .sort((a, b) => b.ids.length - a.ids.length);
+    return groupByDest(persons, this.destResolver());
   }
 }

--- a/metro/src/app/train/station-card/station-card.component.ts
+++ b/metro/src/app/train/station-card/station-card.component.ts
@@ -49,6 +49,8 @@ import { lineColor, fmtCount } from '../../utils/format';
           @if (inspectedPlatformId() === p.id) {
             <app-platform-inspect
               [persons]="personsInPlatform()?.get(p.id)"
+              [platformId]="p.id"
+              [destResolver]="destResolver()"
               (closeInspect)="platformInspect.emit(p.id)"
               (personSelect)="personSelect.emit($event)" />
           }
@@ -61,10 +63,11 @@ export class StationCardComponent {
   item               = input.required<StationLabelItem>();
   inspectedPlatformId = input<string | null>(null);
   personsInPlatform  = input<ReadonlyMap<string, PersonEntry[]> | null>(null);
+  destResolver       = input<(code: string) => string>(code => code);
 
   labelClick     = output<void>();
   platformInspect = output<string>();
-  personSelect   = output<string>();
+  personSelect   = output<{ personId: string; platformId: string }>();
 
   lineColor = lineColor;
   fmt       = fmtCount;

--- a/metro/src/app/train/train-panel/train-panel.component.ts
+++ b/metro/src/app/train/train-panel/train-panel.component.ts
@@ -23,7 +23,7 @@ export class TrainPanelComponent {
   panelY   = input.required<number>();
 
   close        = output<void>();
-  selectPerson = output<string>();
+  selectPerson = output<{ personId: string; trainId: string }>();
 
   inspectMode       = false;
   expandedTrainDest: string | null = null;
@@ -55,7 +55,7 @@ export class TrainPanelComponent {
 
   onSelectPerson(personId: string): void {
     this.inspectMode = false;
-    this.selectPerson.emit(personId);
+    this.selectPerson.emit({ personId, trainId: this.train()?.id ?? '' });
   }
 
   onClose(): void {

--- a/metro/src/app/train/train.component.html
+++ b/metro/src/app/train/train.component.html
@@ -25,9 +25,10 @@
             [item]="item"
             [inspectedPlatformId]="inspectedPlatformId()"
             [personsInPlatform]="state.personsInPlatform()"
+            [destResolver]="resolveDestLabel.bind(this)"
             (labelClick)="onStationLabelClick(idx)"
             (platformInspect)="togglePlatformInspect($event)"
-            (personSelect)="selectPerson($event)" />
+            (personSelect)="selectPerson($event.personId, { type: 'platform', id: $event.platformId })" />
         </div>
       }
     </div>
@@ -40,12 +41,12 @@
       [panelX]="trainPanelX"
       [panelY]="trainPanelY"
       (close)="selectedTrainId = null"
-      (selectPerson)="selectPerson($event)" />
+      (selectPerson)="selectPersonFromTrain($event)" />
   }
 
-  <!-- Person tracker -->
+  <!-- Buddy panel -->
   @if (state.tracked()?.id) {
-    <app-person-tracker />
+    <app-buddy-panel />
   }
 
   <!-- Corner brackets -->

--- a/metro/src/app/train/train.component.ts
+++ b/metro/src/app/train/train.component.ts
@@ -18,7 +18,7 @@ import { lineColor, fmtCount, groupByDest } from '../utils/format';
 import { NodeId } from '../utils/node-id';
 import { computeArcLens } from '../utils/path-geometry';
 
-import { PersonTrackerComponent } from './person-tracker/person-tracker.component';
+import { BuddyPanelComponent } from './buddy-panel/buddy-panel.component';
 import { TrainPanelComponent } from './train-panel/train-panel.component';
 import { TelemetryPanelComponent } from './telemetry-panel/telemetry-panel.component';
 import { ControlPanelComponent } from './control-panel/control-panel.component';
@@ -30,7 +30,7 @@ import { StationLabelItem } from './station-label-item';
 @Component({
   selector: 'app-train',
   standalone: true,
-  imports: [NgClass, PersonTrackerComponent, TrainPanelComponent, TelemetryPanelComponent, ControlPanelComponent, MapInteractionDirective, StationCardComponent, BottomTelemetryComponent],
+  imports: [NgClass, BuddyPanelComponent, TrainPanelComponent, TelemetryPanelComponent, ControlPanelComponent, MapInteractionDirective, StationCardComponent, BottomTelemetryComponent],
   templateUrl: './train.component.html',
   styleUrls: ['./train.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -410,10 +410,14 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
     this.trainPanelY = v.y * this.viewport.scale() + this.viewport.panY();
   }
 
-  selectPerson(personId: string): void {
-    this.state.trackPerson(personId);
+  selectPerson(personId: string, initialLoc?: { type: 'station' | 'platform' | 'train'; id: string }): void {
+    this.state.trackPerson(personId, initialLoc ?? null);
     this.wsService.trackPerson(personId);
     this.wsService.resume();
+  }
+
+  selectPersonFromTrain(event: { personId: string; trainId: string }): void {
+    this.selectPerson(event.personId, { type: 'train', id: event.trainId });
   }
 
   togglePlatformInspect(anderId: string): void {
@@ -520,7 +524,7 @@ export class TrainComponent implements AfterViewInit, OnDestroy, OnInit {
   lineColors(line: string): string { return lineColor(line); }
   fmtCount(n: number): string { return fmtCount(n); }
 
-  private resolveDestLabel(code: string): string {
+  resolveDestLabel(code: string): string {
     return this.metroData.stationsByCode.get(code)?.name ?? code;
   }
 


### PR DESCRIPTION
## Summary

- **Nuevo `app-buddy-panel`**: barra horizontal centrada (70vw, bottom-center) que reemplaza `app-person-tracker`. Muestra ubicación actual con badge de tipo (STATION/PLATFORM/TRAIN), origen → destino, tiempo de viaje en curso y lista de próximas paradas con detección de trasbordos. Mismo sistema visual que los paneles laterales (`control-panel`, `telemetry-panel`).
- **Fix dot invisible en tren**: `resolveLocToPos` no manejaba `loc.type === 'train'` y devolvía `null`, haciendo desaparecer el dot durante todo el trayecto en tren. Ahora recibe los `trainViews` del renderer (ya interpolados) y posiciona el dot sobre el tren.
- **Fix loc inicial**: al seleccionar un usuario desde el panel de tren o de andén, se establece `loc` inmediatamente sin esperar el primer `personLocation` del servidor. El `trainId` / `platformId` se propagan a través de `platform-inspect → station-card → train.component`.
- **Fix tiempo congelado al llegar**: el simulador detecta cuando la persona rastreada llega a su destino (`ArrivedToDestination` en `Simulator.scala`) y envía `personArrived` por WebSocket. El frontend guarda `arrivedAtMs` en `TrackedPerson` y el cronómetro queda congelado en ese valor.
- **Fix destination labels**: los nombres de destino en `platform-inspect` se resuelven al nombre de estación via `destResolver`.

## Test plan

- [ ] Seleccionar usuario desde panel de andén → dot aparece inmediatamente en el andén
- [ ] Seleccionar usuario desde panel de tren → dot aparece inmediatamente sobre el tren y se mueve con él
- [ ] Verificar que el dot no desaparece durante el trayecto en tren
- [ ] Verificar que el dot no salta al cambiar de línea (trasbordo)
- [ ] Cerrar panel de tren → buddy panel sigue visible (no solapamiento)
- [ ] Usuario llega a destino → tiempo del panel se congela en el valor final
- [ ] Buddy panel no solapa con control-panel ni telemetry-panel